### PR TITLE
MAP-1379 update NPM dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express": "^4.19.2",
         "express-prom-bundle": "^7.0.0",
         "express-session": "^1.18.0",
-        "govuk-frontend": "^5.3.1",
+        "govuk-frontend": "^5.4.1",
         "helmet": "^7.1.0",
         "http-errors": "^2.0.0",
         "jquery": "^3.7.1",
@@ -93,7 +93,7 @@
         "sass": "^1.77.1",
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.4.5"
+        "typescript": "^5.5.3"
       },
       "engines": {
         "node": "^20",
@@ -7140,9 +7140,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.1.tgz",
-      "integrity": "sha512-EzegdVdmZVwXUGTQTsBgK4TkMpMyPdOIa2g1kvwX7EeyP9Kah+amXSo97gbiI8N49L6E0J6/2H6qLW4QN3KhMQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
+      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -12251,10 +12252,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "express": "^4.19.2",
     "express-prom-bundle": "^7.0.0",
     "express-session": "^1.18.0",
-    "govuk-frontend": "^5.3.1",
+    "govuk-frontend": "^5.4.1",
     "helmet": "^7.1.0",
     "http-errors": "^2.0.0",
     "jquery": "^3.7.1",
@@ -177,6 +177,6 @@
     "sass": "^1.77.1",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.3"
   }
 }


### PR DESCRIPTION
Focusing on typescript and govuk-frontend to get rid of the alerts we get daily

![image](https://github.com/user-attachments/assets/e952b578-8d10-4e87-9b99-b169528784b8)
