### PR TITLE
[MAP-1271] Don't crash when prisoner locations are not returned

### DIFF
--- a/server/controllers/changeCellCapacity/index.test.ts
+++ b/server/controllers/changeCellCapacity/index.test.ts
@@ -103,6 +103,14 @@ describe('ChangeCellCapacity', () => {
         },
       })
     })
+
+    it('does not when current occupancy is undefined', () => {
+      res.locals.prisonerLocation = undefined
+      const callback = jest.fn()
+      controller.validateFields(req, res, callback)
+
+      expect(callback).toHaveBeenCalledWith({})
+    })
   })
 
   describe('validate', () => {

--- a/server/controllers/changeCellCapacity/index.ts
+++ b/server/controllers/changeCellCapacity/index.ts
@@ -45,7 +45,7 @@ export default class ChangeCellCapacity extends FormInitialStep {
       }
 
       if (!errors.maxCapacity) {
-        const occupants = res.locals.prisonerLocation.prisoners
+        const occupants = res.locals.prisonerLocation?.prisoners || []
 
         if (Number(values?.maxCapacity) < occupants.length) {
           validationErrors.maxCapacity = this.formError('maxCapacity', 'isNoLessThanOccupancy')


### PR DESCRIPTION
This seems to happen when the cell is inactive, causing an error for the user

[MAP-1271]

[MAP-1271]: https://dsdmoj.atlassian.net/browse/MAP-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ