### PR TITLE
Change back links to follow new pattern

### DIFF
--- a/integration_tests/e2e/changeCellCapacity/index.cy.ts
+++ b/integration_tests/e2e/changeCellCapacity/index.cy.ts
@@ -17,7 +17,7 @@ context('Change cell capacity', () => {
 
     it('redirects user to sign in page', () => {
       cy.signIn()
-      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
       Page.verifyOnPage(AuthSignInPage)
     })
   })
@@ -100,7 +100,7 @@ context('Change cell capacity', () => {
     })
 
     it('can be accessed by clicking the change working capacity link on the show location page', () => {
-      cy.visit('/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000000')
+      cy.visit('/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001')
       const viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
       viewLocationsShowPage.summaryCards.workingCapacityChangeLink().click()
 
@@ -108,7 +108,7 @@ context('Change cell capacity', () => {
     })
 
     it('can be accessed by clicking the change maximum capacity link on the show location page', () => {
-      cy.visit('/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000000')
+      cy.visit('/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001')
       const viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
       viewLocationsShowPage.summaryCards.maximumCapacityChangeLink().click()
 
@@ -116,7 +116,7 @@ context('Change cell capacity', () => {
     })
 
     it('has a back link to the show location page', () => {
-      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
       const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
       changeCellCapacityPage.backLink().click()
 
@@ -124,14 +124,14 @@ context('Change cell capacity', () => {
     })
 
     it('has the correct main heading and a caption showing the cell description', () => {
-      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
 
       cy.get('h1').contains('Change cell capacity')
       cy.get('.govuk-caption-m').contains('Cell 1-1-001')
     })
 
     it('has a cancel link', () => {
-      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
       const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
       changeCellCapacityPage.cancelLink().click()
 
@@ -140,7 +140,7 @@ context('Change cell capacity', () => {
 
     describe('validations', () => {
       it('shows the correct validation error when missing working capacity', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('3')
@@ -153,7 +153,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when working capacity > 99', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('3')
@@ -166,7 +166,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when working capacity is not a number', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('3')
@@ -179,7 +179,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when working capacity is greater than max capacity', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('2')
@@ -192,7 +192,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when working capacity is zero for non-specialist cell', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('2')
@@ -205,7 +205,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when missing max capacity', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear()
@@ -218,7 +218,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when max capacity > 99', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('100')
@@ -231,7 +231,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when max capacity is not a number', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('hello')
@@ -244,7 +244,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct validation error when max capacity is less than current occupancy', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('1')
@@ -261,7 +261,7 @@ context('Change cell capacity', () => {
       })
 
       it('redirects back to the view locations page when there is no change', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
 
         changeCellCapacityPage.maxCapacityInput().clear().type('2')
@@ -274,7 +274,7 @@ context('Change cell capacity', () => {
 
     describe('confirm cell capacity', () => {
       it('has a back link to the show location page', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.continueButton().click()
@@ -286,7 +286,7 @@ context('Change cell capacity', () => {
       })
 
       it('has a change link from the summary list', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.continueButton().click()
@@ -298,7 +298,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct summary list', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.maxCapacityInput().clear().type('3')
@@ -313,7 +313,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct change summary when changing one value', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.continueButton().click()
@@ -326,7 +326,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the correct change summary when changing both values', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.maxCapacityInput().clear().type('3')
@@ -342,7 +342,7 @@ context('Change cell capacity', () => {
       })
 
       it('has a cancel link', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.continueButton().click()
@@ -354,7 +354,7 @@ context('Change cell capacity', () => {
       })
 
       it('shows the success banner when the change is complete', () => {
-        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000000')
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
         const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
         changeCellCapacityPage.workingCapacityInput().clear().type('1')
         changeCellCapacityPage.maxCapacityInput().clear().type('3')

--- a/server/controllers/changeCellCapacity/cancel.ts
+++ b/server/controllers/changeCellCapacity/cancel.ts
@@ -1,9 +1,0 @@
-import { NextFunction, Response } from 'express'
-import FormWizard from 'hmpo-form-wizard'
-
-export default class CancelChangeCellCapacity extends FormWizard.Controller {
-  get(req: FormWizard.Request, res: Response, next: NextFunction) {
-    const { location } = res.locals
-    res.redirect(`/view-and-update-locations/${location.prisonId}/${location.id}`)
-  }
-}

--- a/server/controllers/changeCellCapacity/confirm.test.ts
+++ b/server/controllers/changeCellCapacity/confirm.test.ts
@@ -22,6 +22,7 @@ describe('ConfirmCellCapacity', () => {
           maxCapacity: 2,
           workingCapacity: 2,
         },
+        prisonId: 'TST',
       },
       residentialSummary: {
         prisonSummary: {
@@ -36,8 +37,8 @@ describe('ConfirmCellCapacity', () => {
     it('formats the change summary correctly', () => {
       const result = controller.locals(req, res)
       expect(result).toEqual({
-        backLink: '/location/e07effb3-905a-4f6b-acdc-fafbb43a1ee2/change-cell-capacity',
-        cancelLink: '/location/e07effb3-905a-4f6b-acdc-fafbb43a1ee2/change-cell-capacity/cancel',
+        backLink: '/location/e07effb3-905a-4f6b-acdc-fafbb43a1ee2/change-cell-capacity/change',
+        cancelLink: '/view-and-update-locations/TST/e07effb3-905a-4f6b-acdc-fafbb43a1ee2',
         changeSummary: `You are decreasing the cell’s working capacity by 1.
 <br/><br/>
 This will decrease the establishment’s working capacity from 20 to 19.

--- a/server/controllers/changeCellCapacity/confirm.ts
+++ b/server/controllers/changeCellCapacity/confirm.ts
@@ -35,6 +35,7 @@ export default class ConfirmCellCapacity extends FormWizard.Controller {
 
   locals(req: FormWizard.Request, res: Response): object {
     const { location } = res.locals
+    const { id: locationId, prisonId } = location
     const { maxCapacity, workingCapacity } = location.capacity
 
     const newWorkingCap = Number(req.sessionModel.get('workingCapacity'))
@@ -58,11 +59,11 @@ export default class ConfirmCellCapacity extends FormWizard.Controller {
 
     const changeSummary = changeSummaries.join('\n<br/><br/>\n')
 
-    const backLink = backUrl(req, { fallbackUrl: `/location/${location.id}/change-cell-capacity` })
+    const backLink = backUrl(req, { fallbackUrl: `/location/${location.id}/change-cell-capacity/change` })
 
     return {
       backLink,
-      cancelLink: `/location/${location.id}/change-cell-capacity/cancel`,
+      cancelLink: `/view-and-update-locations/${prisonId}/${locationId}`,
       changeSummary,
     }
   }

--- a/server/controllers/changeCellCapacity/index.test.ts
+++ b/server/controllers/changeCellCapacity/index.test.ts
@@ -37,6 +37,7 @@ describe('ChangeCellCapacity', () => {
             maxCapacity: 2,
             workingCapacity: 2,
           },
+          prisonId: 'MDI',
         },
         options: {
           fields,
@@ -119,9 +120,7 @@ describe('ChangeCellCapacity', () => {
       res.redirect = jest.fn()
       controller.validate(req, res, jest.fn())
 
-      expect(res.redirect).toHaveBeenCalledWith(
-        '/location/e07effb3-905a-4f6b-acdc-fafbb43a1ee2/change-cell-capacity/cancel',
-      )
+      expect(res.redirect).toHaveBeenCalledWith('/view-and-update-locations/MDI/e07effb3-905a-4f6b-acdc-fafbb43a1ee2')
     })
   })
 
@@ -141,7 +140,6 @@ describe('ChangeCellCapacity', () => {
 
       expect(result).toEqual({
         backLink: '/referrer-url',
-        cancelLink: '/location/e07effb3-905a-4f6b-acdc-fafbb43a1ee2/change-cell-capacity/cancel',
         fields,
         validationErrors: [
           {

--- a/server/controllers/changeCellCapacity/index.ts
+++ b/server/controllers/changeCellCapacity/index.ts
@@ -58,11 +58,12 @@ export default class ChangeCellCapacity extends FormInitialStep {
 
   validate(req: FormWizard.Request, res: Response, next: NextFunction) {
     const { location } = res.locals
+    const { id: locationId, prisonId } = location
     const { maxCapacity: newMaxCap, workingCapacity: newWorkingCap } = req.form.values
     const { maxCapacity, workingCapacity } = location.capacity
 
     if (Number(newMaxCap) === maxCapacity && Number(newWorkingCap) === workingCapacity) {
-      return res.redirect(`/location/${location.id}/change-cell-capacity/cancel`)
+      return res.redirect(`/view-and-update-locations/${prisonId}/${locationId}`)
     }
 
     return next()
@@ -80,7 +81,6 @@ export default class ChangeCellCapacity extends FormInitialStep {
     return {
       ...locals,
       backLink,
-      cancelLink: `/location/${locationId}/change-cell-capacity/cancel`,
     }
   }
 }

--- a/server/controllers/setCellType/cancel.ts
+++ b/server/controllers/setCellType/cancel.ts
@@ -1,9 +1,0 @@
-import { NextFunction, Response } from 'express'
-import FormWizard from 'hmpo-form-wizard'
-
-export default class CancelSetCellType extends FormWizard.Controller {
-  get(req: FormWizard.Request, res: Response, next: NextFunction) {
-    const { location } = res.locals
-    res.redirect(`/view-and-update-locations/${location.prisonId}/${location.id}`)
-  }
-}

--- a/server/controllers/setCellType/index.test.ts
+++ b/server/controllers/setCellType/index.test.ts
@@ -136,8 +136,7 @@ describe('SetCellType', () => {
       const result = controller.locals(req, res)
 
       expect(result).toEqual({
-        backLink: '/location/7e570000-0000-0000-0000-000000000001/set-cell-type/cancel',
-        cancelLink: '/location/7e570000-0000-0000-0000-000000000001/set-cell-type/cancel',
+        backLink: '/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001',
         fields,
         pageTitleText: 'Change specific cell type',
         validationErrors: [
@@ -156,7 +155,7 @@ describe('SetCellType', () => {
       res.redirect = jest.fn()
       controller.validate(req, res, jest.fn())
 
-      expect(res.redirect).toHaveBeenCalledWith('/location/7e570000-0000-0000-0000-000000000001/set-cell-type/cancel')
+      expect(res.redirect).toHaveBeenCalledWith('/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001')
     })
   })
 

--- a/server/controllers/setCellType/index.ts
+++ b/server/controllers/setCellType/index.ts
@@ -2,6 +2,7 @@ import FormWizard from 'hmpo-form-wizard'
 import { NextFunction, Response } from 'express'
 import { isEqual, sortBy } from 'lodash'
 import FormInitialStep from '../base/formInitialStep'
+import backUrl from '../../utils/backUrl'
 
 export default class SetCellType extends FormInitialStep {
   async configure(req: FormWizard.Request, res: Response, next: NextFunction) {
@@ -24,10 +25,9 @@ export default class SetCellType extends FormInitialStep {
   locals(req: FormWizard.Request, res: Response): object {
     const locals = super.locals(req, res)
     const { location } = res.locals
+    const { id: locationId, prisonId } = location
 
     const pageTitleText = location.specialistCellTypes.length ? 'Change specific cell type' : 'Set specific cell type'
-
-    const cancelLink = `/location/${location.id}/set-cell-type/cancel`
 
     const fields = { ...locals.fields }
 
@@ -39,10 +39,13 @@ export default class SetCellType extends FormInitialStep {
       fields.specialistCellTypes.items = items
     }
 
+    const backLink = backUrl(req, {
+      fallbackUrl: `/view-and-update-locations/${prisonId}/${locationId}`,
+    })
+
     return {
       ...locals,
-      backLink: cancelLink,
-      cancelLink,
+      backLink,
       fields,
       pageTitleText,
     }
@@ -50,9 +53,10 @@ export default class SetCellType extends FormInitialStep {
 
   validate(req: FormWizard.Request, res: Response, next: NextFunction) {
     const { location } = res.locals
+    const { id: locationId, prisonId } = location
 
     if (isEqual(sortBy(req.form.values.specialistCellTypes), sortBy(location.specialistCellTypes))) {
-      return res.redirect(`/location/${location.id}/set-cell-type/cancel`)
+      return res.redirect(`/view-and-update-locations/${prisonId}/${locationId}`)
     }
 
     return next()

--- a/server/routes/changeCellCapacity/steps.ts
+++ b/server/routes/changeCellCapacity/steps.ts
@@ -1,23 +1,22 @@
 import ChangeCellCapacity from '../../controllers/changeCellCapacity'
 import ConfirmCellCapacity from '../../controllers/changeCellCapacity/confirm'
-import CancelChangeCellCapacity from '../../controllers/changeCellCapacity/cancel'
 
 const steps = {
   '/': {
     entryPoint: true,
-    fields: ['workingCapacity', 'maxCapacity'],
-    next: 'confirm',
-    controller: ChangeCellCapacity,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'change',
   },
   '/confirm': {
     fields: ['confirm'],
     controller: ConfirmCellCapacity,
   },
-  '/cancel': {
-    checkJourney: false,
-    reset: true,
-    resetJourney: true,
-    controller: CancelChangeCellCapacity,
+  '/change': {
+    fields: ['workingCapacity', 'maxCapacity'],
+    next: 'confirm',
+    controller: ChangeCellCapacity,
   },
 }
 

--- a/server/routes/setCellType/steps.ts
+++ b/server/routes/setCellType/steps.ts
@@ -1,17 +1,16 @@
 import SetCellType from '../../controllers/setCellType'
-import CancelSetCellType from '../../controllers/setCellType/cancel'
 
 const steps = {
   '/': {
     entryPoint: true,
-    fields: ['specialistCellTypes'],
-    controller: SetCellType,
-  },
-  '/cancel': {
-    checkJourney: false,
     reset: true,
     resetJourney: true,
-    controller: CancelSetCellType,
+    skip: true,
+    next: 'change',
+  },
+  '/change': {
+    fields: ['specialistCellTypes'],
+    controller: SetCellType,
   },
 }
 

--- a/server/views/pages/changeCellCapacity/change.njk
+++ b/server/views/pages/changeCellCapacity/change.njk
@@ -75,20 +75,12 @@
               type: "submit"
             }) }}
           {% endblock %}
-
-          {% block cancelAction %}
-            {% if cancelUrl %}
-              <a href="{{ cancelUrl }}" class="govuk-link">
-                Cancel
-              </a>
-            {% endif %}
-          {% endblock %}
         {% endblock %}
       </div>
     </form>
 
     <p class="govuk-body">
-      <a href="{{ cancelLink }}" class="govuk-link govuk-link--no-visited-state">
+      <a href="{{ backLink }}" class="govuk-link govuk-link--no-visited-state">
         Cancel and return to location details
       </a>
     </p>

--- a/server/views/pages/setCellType/change.njk
+++ b/server/views/pages/setCellType/change.njk
@@ -98,7 +98,7 @@
     </div>
 
     <p class="govuk-body">
-      <a href="{{ cancelLink }}" class="govuk-link govuk-link--no-visited-state">
+      <a href="{{ backLink }}" class="govuk-link govuk-link--no-visited-state">
         Cancel and return to location details
       </a>
     </p>


### PR DESCRIPTION
We have removed the /cancel endpoints and instead we reset when the user visits / and immediately redirect to /change. If we are linking back and don't want to reset then we just link straight to /change.

See: https://github.com/ministryofjustice/hmpps-locations-inside-prison/pull/61