### PR TITLE
[MAP-1474] Use express-async-errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "csurf": "^1.11.0",
         "date-fns": "^3.6.0",
         "express": "^4.19.2",
+        "express-async-errors": "^3.1.1",
         "express-prom-bundle": "^7.0.0",
         "express-session": "^1.18.0",
         "govuk-frontend": "^5.4.1",
@@ -6585,6 +6586,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-prom-bundle": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "csurf": "^1.11.0",
     "date-fns": "^3.6.0",
     "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
     "express-prom-bundle": "^7.0.0",
     "express-session": "^1.18.0",
     "govuk-frontend": "^5.4.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import 'express-async-errors'
 
 import createError from 'http-errors'
 import cookieParser from 'cookie-parser'


### PR DESCRIPTION
This should stop it crashing when API calls fail

MAP-1474