### PR TITLE
[MAP-1474] Rework the styling of the error page a bit

### DIFF
--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,14 +1,16 @@
 {% extends "../partials/layout.njk" %}
 
-{% set title = message %}
+{% set title = message if message else applicationName + " - Error" %}
 
 {% block pageTitle %}{{ applicationName }} - Error{% endblock %}
 
-{% block beforeContent %}
-
-  {{ super() }}
-
-  <h2>{{ status }}</h2>
-  <pre>{{ stack }}</pre>
-
+{% block content %}
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">{{ status }}</h2>
+        <pre>{{ stack }}</pre>
+      </div>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Some of the text was spilling out of the page grid layout, and the status code was displaying above the title.

MAP-1474