### PR TITLE
MAP-1400 - Add missing Residential locations breadcrumb

### DIFF
--- a/server/routes/viewLocationsRouter.ts
+++ b/server/routes/viewLocationsRouter.ts
@@ -11,6 +11,7 @@ import populateBreadcrumbsForLocation from '../middleware/populateBreadcrumbsFor
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import addAction from '../middleware/addAction'
 import { DecoratedLocation } from '../decorators/decoratedLocation'
+import addBreadcrumb from '../middleware/addBreadcrumb'
 
 const router = express.Router({ mergeParams: true })
 
@@ -44,6 +45,7 @@ const controller = (services: Services) => {
     '/',
     populateResidentialSummary(services),
     populateBreadcrumbsForLocation,
+    addBreadcrumb({ title: '', href: '/' }),
     logPageView(services.auditService, Page.LOCATIONS_INDEX),
     viewLocationsIndex,
   )


### PR DESCRIPTION
Related to the following ticket: [MAP-1400](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-1400)

Changes made in this PR:
- Add missing breadcrumb

Supporting screenshots:

<img width="1263" alt="Screenshot 2024-09-16 at 16 02 17" src="https://github.com/user-attachments/assets/087f661e-37f4-4e2c-8e64-06a8bc713991">


[MAP-1400]: https://dsdmoj.atlassian.net/browse/MAP-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ