### PR TITLE
MAP-1660: Allow access to all environments for three IP ranges

### DIFF
--- a/helm_deploy/hmpps-locations-inside-prison/values.yaml
+++ b/helm_deploy/hmpps-locations-inside-prison/values.yaml
@@ -65,7 +65,9 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+      - prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-locations-inside-prison

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,10 +18,5 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
 
-  allowlist:
-    groups:
-      - digital_staff_and_mojo
-      - prisons
-
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,10 +15,5 @@ generic-service:
     LOCATIONS_API_URL: "https://locations-inside-prison-api.hmpps.service.justice.gov.uk"
     AUDIT_ENABLED: "false"
 
-  allowlist:
-    groups:
-      - digital_staff_and_mojo
-      - prisons
-
 generic-prometheus-alerts:
   alertSeverity: hmpps-prisoner-cell-allocation-prod

--- a/helm_deploy/values-train.yaml
+++ b/helm_deploy/values-train.yaml
@@ -18,11 +18,6 @@ generic-service:
     LOCATIONS_API_URL: "https://locations-inside-prison-api-train.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: TRAINING
     AUDIT_ENABLED: "false"
-
-  allowlist:
-    groups:
-      - digital_staff_and_mojo
-      - prisons
       
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
We need prisons to have access because some MoJ laptops show up as being in this IP range, including a performance analyst who is helping us.

We need Cloud Platforms to have access so that the Dev Portal can keep track of drift.

The other IP group will allow the rest of us access.

The `internal` group has been removed because it is deprecated.

MAP-1660