### PR TITLE
MAP-1661: Send GA events when completing transaction

### DIFF
--- a/server/controllers/cellConversion/confirm.test.ts
+++ b/server/controllers/cellConversion/confirm.test.ts
@@ -5,6 +5,7 @@ import LocationsService from '../../services/locationsService'
 import LocationFactory from '../../testutils/factories/location'
 import CellConversionConfirm from './confirm'
 import fields from '../../routes/cellConversion/fields'
+import AnalyticsService from '../../services/analyticsService'
 
 describe('CellConversionConfirm', () => {
   const controller = new CellConversionConfirm({ route: '/' })
@@ -16,6 +17,8 @@ describe('CellConversionConfirm', () => {
   let sessionModelUnset: jest.Mock
   const authService = new AuthService(null) as jest.Mocked<AuthService>
   const locationsService = new LocationsService(null) as jest.Mocked<LocationsService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
+
   const formValues: any = {
     accommodationType: 'NORMAL_ACCOMMODATION',
     maxCapacity: 2,
@@ -39,6 +42,7 @@ describe('CellConversionConfirm', () => {
         reset: jest.fn(),
       },
       services: {
+        analyticsService,
         authService,
         locationsService,
       },
@@ -97,6 +101,7 @@ describe('CellConversionConfirm', () => {
     locationsService.getSpecialistCellType = jest.fn().mockImplementation((_, key) => allSpecialistCellTypes[key])
     locationsService.getUsedForType = jest.fn().mockImplementation((_, key) => allUsedForTypes[key])
     locationsService.convertToCell = jest.fn()
+    analyticsService.sendEvent = jest.fn()
   })
 
   describe('get', () => {
@@ -230,6 +235,15 @@ describe('CellConversionConfirm', () => {
     it('calls next when successful', async () => {
       await controller.saveValues(req, res, next)
       expect(next).toHaveBeenCalled()
+    })
+
+    it('sends an analytics event when successful', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(req, 'convert_to_cell', {
+        prison_id: 'TST',
+        accommodation_type: 'NORMAL_ACCOMMODATION',
+      })
     })
 
     it('calls next with any unexpected errors', async () => {

--- a/server/controllers/changeCellCapacity/confirm.test.ts
+++ b/server/controllers/changeCellCapacity/confirm.test.ts
@@ -1,35 +1,66 @@
-import { Response } from 'express'
+import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import ConfirmCellCapacity from './confirm'
+import LocationsService from '../../services/locationsService'
+import AuthService from '../../services/authService'
+import AnalyticsService from '../../services/analyticsService'
 
 describe('ConfirmCellCapacity', () => {
   const controller = new ConfirmCellCapacity({ route: '/' })
-  const req: FormWizard.Request = {
-    session: {
-      referrerUrl: '/',
-    },
-    sessionModel: {
-      get: jest.fn((fieldName?: string) => ({ maxCapacity: '3', workingCapacity: '1' })[fieldName]),
-    },
-  } as unknown as typeof req
-  const res: Response = {
-    locals: {
-      location: {
-        id: 'e07effb3-905a-4f6b-acdc-fafbb43a1ee2',
-        capacity: {
-          maxCapacity: 2,
-          workingCapacity: 2,
-        },
-        prisonId: 'TST',
-      },
-      residentialSummary: {
-        prisonSummary: {
-          maxCapacity: 30,
-          workingCapacity: 20,
+  let req: FormWizard.Request
+  let res: Response
+  let next: NextFunction
+  const authService = new AuthService(null) as jest.Mocked<AuthService>
+  const locationsService = new LocationsService(null) as jest.Mocked<LocationsService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
+
+  beforeEach(() => {
+    req = {
+      form: {
+        values: {
+          maxCapacity: '3',
+          workingCapacity: '1',
         },
       },
-    },
-  } as unknown as typeof res
+      services: {
+        analyticsService,
+        authService,
+        locationsService,
+      },
+      session: {
+        referrerUrl: '/',
+      },
+      sessionModel: {
+        get: jest.fn((fieldName?: string) => ({ maxCapacity: '3', workingCapacity: '1' })[fieldName]),
+      },
+    } as unknown as typeof req
+    res = {
+      locals: {
+        location: {
+          id: 'e07effb3-905a-4f6b-acdc-fafbb43a1ee2',
+          capacity: {
+            maxCapacity: 2,
+            workingCapacity: 2,
+          },
+          prisonId: 'TST',
+        },
+        residentialSummary: {
+          prisonSummary: {
+            maxCapacity: 30,
+            workingCapacity: 20,
+          },
+        },
+        user: {
+          username: 'HSLUGHORN',
+        },
+      },
+    } as unknown as typeof res
+    next = jest.fn()
+
+    authService.getSystemClientToken = jest.fn().mockResolvedValue('token')
+    locationsService.updateCapacity = jest.fn()
+    analyticsService.sendEvent = jest.fn()
+  })
 
   describe('locals', () => {
     it('formats the change summary correctly', () => {
@@ -45,6 +76,26 @@ You are increasing the cell’s maximum capacity by 1.
 <br/><br/>
 This will increase the establishment’s maximum capacity from 30 to 31.`,
       })
+    })
+  })
+
+  describe('saveValues', () => {
+    it('calls locationsService', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(locationsService.updateCapacity).toHaveBeenCalledWith('token', res.locals.location.id, 3, 1)
+    })
+
+    it('sends an analytics event', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(req, 'change_cell_capacity', { prison_id: 'TST' })
+    })
+
+    it('calls next', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(next).toHaveBeenCalled()
     })
   })
 })

--- a/server/controllers/changeCellCapacity/confirm.ts
+++ b/server/controllers/changeCellCapacity/confirm.ts
@@ -61,16 +61,18 @@ export default class ConfirmCellCapacity extends FormWizard.Controller {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
 
       const token = await req.services.authService.getSystemClientToken(user.username)
       await locationsService.updateCapacity(
         token,
-        res.locals.location.id,
+        location.id,
         Number(req.sessionModel.get('maxCapacity')),
         Number(req.sessionModel.get('workingCapacity')),
       )
+
+      req.services.analyticsService.sendEvent(req, 'change_cell_capacity', { prison_id: location.prisonId })
 
       next()
     } catch (error) {

--- a/server/controllers/changeSignedOperationalCapacity/index.ts
+++ b/server/controllers/changeSignedOperationalCapacity/index.ts
@@ -101,16 +101,18 @@ export default class ChangeSignedOperationalCapacity extends FormInitialStep {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { prisonId, user } = res.locals
       const { locationsService } = req.services
       const { newSignedOperationalCapacity } = req.form.values
       const token = await req.services.authService.getSystemClientToken(user.username)
       await locationsService.updateSignedOperationalCapacity(
         token,
-        res.locals.prisonId,
+        prisonId,
         Number(newSignedOperationalCapacity),
         user.username,
       )
+
+      req.services.analyticsService.sendEvent(req, 'change_signed_op_cap', { prison_id: prisonId })
 
       next()
     } catch (error) {

--- a/server/controllers/changeUsedFor/details.test.ts
+++ b/server/controllers/changeUsedFor/details.test.ts
@@ -5,6 +5,7 @@ import AuthService from '../../services/authService'
 import LocationsService from '../../services/locationsService'
 import LocationFactory from '../../testutils/factories/location'
 import fields from '../../routes/changeUsedFor/fields'
+import AnalyticsService from '../../services/analyticsService'
 
 describe('ChangeUsedForDetails', () => {
   const controller = new ChangeUsedForDetails({ route: '/' })
@@ -13,6 +14,7 @@ describe('ChangeUsedForDetails', () => {
   let next: NextFunction
   const authService = new AuthService(null) as jest.Mocked<AuthService>
   const locationsService = new LocationsService(null) as jest.Mocked<LocationsService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
 
   beforeEach(() => {
     req = {
@@ -29,6 +31,7 @@ describe('ChangeUsedForDetails', () => {
         },
       },
       services: {
+        analyticsService,
         authService,
         locationsService,
       },
@@ -79,6 +82,7 @@ describe('ChangeUsedForDetails', () => {
       { key: 'THERAPEUTIC_COMMUNITY', description: 'Therapeutic community' },
     ])
     locationsService.updateUsedForTypes = jest.fn().mockResolvedValue(true)
+    analyticsService.sendEvent = jest.fn()
   })
 
   describe('setOptions', () => {
@@ -163,6 +167,12 @@ describe('ChangeUsedForDetails', () => {
         res.locals.location.id,
         req.form.values.usedFor,
       )
+    })
+
+    it('sends an analytics event', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(req, 'change_used_for', { prison_id: 'TST' })
     })
 
     it('calls next', () => {

--- a/server/controllers/changeUsedFor/details.ts
+++ b/server/controllers/changeUsedFor/details.ts
@@ -50,11 +50,14 @@ export default class ChangeUsedForDetails extends FormInitialStep {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
       const token = await req.services.authService.getSystemClientToken(user.username)
       const usedFor = req.form.values.usedFor as string[]
-      await locationsService.updateUsedForTypes(token, res.locals.location.id, usedFor)
+      await locationsService.updateUsedForTypes(token, location.id, usedFor)
+
+      req.services.analyticsService.sendEvent(req, 'change_used_for', { prison_id: location.prisonId })
+
       next()
     } catch (error) {
       next(error)

--- a/server/controllers/deactivateTemporary/confirm.ts
+++ b/server/controllers/deactivateTemporary/confirm.ts
@@ -95,6 +95,12 @@ export default class DeactivateTemporaryConfirm extends FormWizard.Controller {
         req.sessionModel.get('planetFmReference') as string,
       )
 
+      req.services.analyticsService.sendEvent(req, 'deactivate_temp', {
+        prison_id: location.prisonId,
+        location_type: location.locationType,
+        deactivation_reason: reason,
+      })
+
       next()
     } catch (error) {
       next(error)

--- a/server/controllers/nonResidentialConversion/confirm.ts
+++ b/server/controllers/nonResidentialConversion/confirm.ts
@@ -39,7 +39,7 @@ export default class NonResidentialConversionConfirm extends FormWizard.Controll
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
       const convertedCellType = req.sessionModel.get('convertedCellType') as { text: string; value: string }
       let otherConvertedCellType = req.sessionModel.get('otherConvertedCellType') as string
@@ -50,10 +50,15 @@ export default class NonResidentialConversionConfirm extends FormWizard.Controll
       const token = await req.services.authService.getSystemClientToken(user.username)
       await locationsService.convertCellToNonResCell(
         token,
-        res.locals.location.id,
+        location.id,
         convertedCellType?.value,
         otherConvertedCellType,
       )
+
+      req.services.analyticsService.sendEvent(req, 'convert_to_non_res', {
+        prison_id: location.prisonId,
+        converted_cell_type: convertedCellType.value,
+      })
 
       return next()
     } catch (error) {

--- a/server/controllers/reactivate/cell/confirm.ts
+++ b/server/controllers/reactivate/cell/confirm.ts
@@ -68,13 +68,15 @@ export default class ReactivateCellConfirm extends FormWizard.Controller {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
       const workingCapacity = Number(req.sessionModel.get('workingCapacity'))
       const maxCapacity = Number(req.sessionModel.get('maxCapacity'))
 
       const token = await req.services.authService.getSystemClientToken(user.username)
       await locationsService.reactivateCell(token, res.locals.location.id, { maxCapacity, workingCapacity })
+
+      req.services.analyticsService.sendEvent(req, 'reactivate_cell', { prison_id: location.prisonId })
 
       next()
     } catch (error) {

--- a/server/controllers/removeCellType/confirm.test.ts
+++ b/server/controllers/removeCellType/confirm.test.ts
@@ -4,6 +4,7 @@ import ConfirmRemoveCellType from './confirm'
 import AuthService from '../../services/authService'
 import LocationsService from '../../services/locationsService'
 import LocationFactory from '../../testutils/factories/location'
+import AnalyticsService from '../../services/analyticsService'
 
 describe('ConfirmRemoveCellType', () => {
   const controller = new ConfirmRemoveCellType({ route: '/' })
@@ -12,6 +13,7 @@ describe('ConfirmRemoveCellType', () => {
   let next: NextFunction
   const authService = new AuthService(null) as jest.Mocked<AuthService>
   const locationsService = new LocationsService(null) as jest.Mocked<LocationsService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
 
   beforeEach(() => {
     req = {
@@ -20,6 +22,7 @@ describe('ConfirmRemoveCellType', () => {
         reset: jest.fn(),
       },
       services: {
+        analyticsService,
         authService,
         locationsService,
       },
@@ -57,6 +60,7 @@ describe('ConfirmRemoveCellType', () => {
 
     authService.getSystemClientToken = jest.fn().mockResolvedValue('token')
     locationsService.updateSpecialistCellTypes = jest.fn()
+    analyticsService.sendEvent = jest.fn()
   })
 
   describe('locals', () => {
@@ -94,6 +98,12 @@ This will increase the establishment’s maximum capacity from 30 to 31.`,
           args: ['token', 'e07effb3-905a-4f6b-acdc-fafbb43a1ee2', []],
         },
       ])
+    })
+
+    it('sends an analytics event when successful', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(req, 'remove_cell_type', { prison_id: 'TST' })
     })
 
     it('calls next when successful', async () => {

--- a/server/controllers/removeCellType/confirm.ts
+++ b/server/controllers/removeCellType/confirm.ts
@@ -45,18 +45,20 @@ export default class ConfirmRemoveCellType extends FormWizard.Controller {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
 
       const token = await req.services.authService.getSystemClientToken(user.username)
       await locationsService.updateCapacity(
         token,
-        res.locals.location.id,
+        location.id,
         Number(req.sessionModel.get('maxCapacity')),
         Number(req.sessionModel.get('workingCapacity')),
       )
 
       await locationsService.updateSpecialistCellTypes(token, res.locals.location.id, [])
+
+      req.services.analyticsService.sendEvent(req, 'remove_cell_type', { prison_id: location.prisonId })
 
       next()
     } catch (error) {

--- a/server/controllers/setCellType/index.ts
+++ b/server/controllers/setCellType/index.ts
@@ -61,13 +61,16 @@ export default class SetCellType extends FormInitialStep {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
 
       const token = await req.services.authService.getSystemClientToken(user.username)
 
       const cellTypes = req.form.values.specialistCellTypes as string[]
       await locationsService.updateSpecialistCellTypes(token, res.locals.location.id, cellTypes)
+
+      const eventName = location.specialistCellTypes?.length ? 'change_cell_type' : 'set_cell_type'
+      req.services.analyticsService.sendEvent(req, eventName, { prison_id: location.prisonId })
 
       next()
     } catch (error) {

--- a/server/services/analyticsService.ts
+++ b/server/services/analyticsService.ts
@@ -1,9 +1,20 @@
+import { Request } from 'express'
+import FormWizard from 'hmpo-form-wizard'
 import GoogleAnalyticsClient, { GoogleAnalyticsEvent } from '../data/googleAnalyticsClient'
+import logger from '../../logger'
 
 export default class AnalyticsService {
   constructor(private readonly googleAnalyticsClient: GoogleAnalyticsClient) {}
 
-  async sendEvents(clientId: string, events: GoogleAnalyticsEvent[]) {
-    return this.googleAnalyticsClient.sendEvents(clientId, events)
+  async sendEvent(req: Request | FormWizard.Request, name: string, params: Record<string, any>) {
+    const event: GoogleAnalyticsEvent = { name: `res_locations_${name}`, params }
+
+    try {
+      // eslint-disable-next-line no-underscore-dangle
+      const gaClientId = req.cookies?._ga?.match(/.*\.(\d+\.\d+)$/)[1]
+      return await this.googleAnalyticsClient.sendEvents(gaClientId, [event])
+    } catch (error) {
+      return logger.warn(error, 'Failed to send Google Analytics event')
+    }
   }
 }


### PR DESCRIPTION
Send an event to Google Analytics via the measurement protocol when a transaction is completed.

Some of the controllers were missing tests for `saveValues` so I've added them where necessary.

MAP-1661