### PR TITLE
MAP-1630: Get rid of gap above training header at some screen widths

### DIFF
--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -15,7 +15,7 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-          <h1 class="govuk-heading-xl govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+          <h1 class="govuk-heading-xl govuk-!-padding-top-5 govuk-!-margin-bottom-5">
             Practice using Residential locations
           </h1>
           <p class="govuk-body govuk-!-margin-bottom-6">

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -67,7 +67,7 @@
           <div class="govuk-width-container">
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-three-quarters">
-                <h1 class="govuk-heading-l govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+                <h1 class="govuk-heading-l govuk-!-padding-top-5 govuk-!-margin-bottom-5">
                   Residential locations (practice version)
                 </h1>
                 <a role="button" class="govuk-button govuk-button--inverse" href="{{ productionUrl }}">


### PR DESCRIPTION
### Before

<img width="579" alt="Screenshot 2024-10-04 at 12 28 16" src="https://github.com/user-attachments/assets/09654749-db45-4d8c-a7b8-057f9e2a2a71">
<img width="581" alt="Screenshot 2024-10-04 at 12 28 26" src="https://github.com/user-attachments/assets/6254d098-9b40-4163-babb-f002013e9ffd">

### After

<img width="605" alt="Screenshot 2024-10-04 at 12 37 24" src="https://github.com/user-attachments/assets/c9d4696e-d622-4deb-ba0a-c2030382a802">
<img width="606" alt="Screenshot 2024-10-04 at 12 37 57" src="https://github.com/user-attachments/assets/e1a96cef-7a01-441a-8a83-e5db547f4a07">


MAP-1630