### PR TITLE
Display Unknown in location history when user not found

### DIFF
--- a/server/controllers/locationHistoryShow.test.ts
+++ b/server/controllers/locationHistoryShow.test.ts
@@ -55,4 +55,21 @@ describe('view locations show', () => {
       ],
     })
   })
+
+  describe('when the user is not found', () => {
+    beforeEach(() => {
+      manageUsersService.getUser = jest.fn().mockResolvedValue(null)
+    })
+
+    it('renders the page', async () => {
+      await controller(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/locationHistory/show', {
+        backLink: '/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001',
+        tableRows: [
+          [{ text: 'Location Type' }, { text: 'CELL' }, { text: 'WING' }, { text: 'Unknown' }, { text: '05/07/2021' }],
+        ],
+      })
+    })
+  })
 })

--- a/server/controllers/locationHistoryShow.ts
+++ b/server/controllers/locationHistoryShow.ts
@@ -11,7 +11,8 @@ export default ({ authService, manageUsersService }: Services) =>
 
     const tableRows = await Promise.all(
       changeHistory.map(async ({ amendedBy, amendedDate, attribute, newValue, oldValue }) => {
-        const { name } = await manageUsersService.getUser(token, amendedBy)
+        const user = await manageUsersService.getUser(token, amendedBy)
+        const name = user?.name || 'Unknown'
 
         return [
           { text: attribute },


### PR DESCRIPTION
Sometimes the changes to a location were made by some kind of script, so the user may not have a name. This was causing it to throw an error. Now we just show "Unknown" in that column if the user cannot be found or has no name.

MAP-1629