### PR TITLE
MAP-1661: Send GA event for remove cell type secondary form route

### DIFF
--- a/server/controllers/removeCellType/remove.test.ts
+++ b/server/controllers/removeCellType/remove.test.ts
@@ -5,6 +5,7 @@ import RemoveCellType from './remove'
 import AuthService from '../../services/authService'
 import LocationsService from '../../services/locationsService'
 import LocationFactory from '../../testutils/factories/location'
+import AnalyticsService from '../../services/analyticsService'
 
 describe('RemoveCellType', () => {
   const controller = new RemoveCellType({ route: '/' })
@@ -13,6 +14,7 @@ describe('RemoveCellType', () => {
   let next: NextFunction
   const authService = new AuthService(null) as jest.Mocked<AuthService>
   const locationsService = new LocationsService(null) as jest.Mocked<LocationsService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
 
   beforeEach(() => {
     req = {
@@ -30,6 +32,7 @@ describe('RemoveCellType', () => {
         reset: jest.fn(),
       },
       services: {
+        analyticsService,
         authService,
         locationsService,
       },
@@ -54,6 +57,7 @@ describe('RemoveCellType', () => {
 
     authService.getSystemClientToken = jest.fn().mockResolvedValue('token')
     locationsService.updateSpecialistCellTypes = jest.fn()
+    analyticsService.sendEvent = jest.fn()
   })
 
   describe('locals', () => {
@@ -97,6 +101,12 @@ describe('RemoveCellType', () => {
     it('calls next when successful', async () => {
       await controller.saveValues(req, res, next)
       expect(next).toHaveBeenCalled()
+    })
+
+    it('sends an analytics event when successful', async () => {
+      await controller.saveValues(req, res, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(req, 'remove_cell_type', { prison_id: 'MDI' })
     })
 
     it('calls next with any errors', async () => {

--- a/server/controllers/removeCellType/remove.ts
+++ b/server/controllers/removeCellType/remove.ts
@@ -36,11 +36,13 @@ export default class RemoveCellType extends FormWizard.Controller {
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const { user } = res.locals
+      const { location, user } = res.locals
       const { locationsService } = req.services
 
       const token = await req.services.authService.getSystemClientToken(user.username)
-      await locationsService.updateSpecialistCellTypes(token, res.locals.location.id, [])
+      await locationsService.updateSpecialistCellTypes(token, location.id, [])
+
+      req.services.analyticsService.sendEvent(req, 'remove_cell_type', { prison_id: location.prisonId })
 
       next()
     } catch (error) {


### PR DESCRIPTION
Depending on working cap etc. the final page of the remove cell type journey could be either `/confirm` or `/remove`. This makes sure the GA event still gets sent if they go via the `/remove` page.

MAP-1661