### PR TITLE
MAP-1292 - Add fix for edge case when date values are undefined

### DIFF
--- a/server/controllers/changeTemporaryDeactivationDetails/details.test.ts
+++ b/server/controllers/changeTemporaryDeactivationDetails/details.test.ts
@@ -288,4 +288,21 @@ describe('ChangeTemporaryDeactivationDetails', () => {
       })
     })
   })
+
+  describe('compareInitialAndSubmittedValues', () => {
+    it('should convert undefined date values into empty strings', () => {
+      const initialValues = req.form.values
+      initialValues.estimatedReactivationDate = undefined
+
+      const submittedValues = initialValues
+      submittedValues.estimatedReactivationDate = ''
+
+      expect(
+        controller.compareInitialAndSubmittedValues({
+          initialValues,
+          submittedValues,
+        }),
+      ).toBe(false)
+    })
+  })
 })

--- a/server/controllers/changeTemporaryDeactivationDetails/details.ts
+++ b/server/controllers/changeTemporaryDeactivationDetails/details.ts
@@ -88,7 +88,13 @@ export default class ChangeTemporaryDeactivationDetails extends FormInitialStep 
   }
 
   compareInitialAndSubmittedValues(values: { initialValues: any; submittedValues: any }) {
-    return JSON.stringify(values.initialValues) !== JSON.stringify(values.submittedValues)
+    const initialValues = { ...values.initialValues }
+    Object.keys(initialValues).forEach(key => {
+      if (initialValues[key] === undefined) {
+        initialValues[key] = ''
+      }
+    })
+    return JSON.stringify(initialValues) !== JSON.stringify(values.submittedValues)
   }
 
   async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
- Updates compareInitialAndSubmittedValues() to handle undefined values in the initial data when comparing to the submitted empty string data. This only occurs when the date fields are initially empty and 'undefined' is returns from the API. 
- Added supporting unit test