### PR TITLE
MAP-1489: Remove indefinite caching in locations service

### DIFF
--- a/server/services/locationsService.test.ts
+++ b/server/services/locationsService.test.ts
@@ -56,13 +56,13 @@ describe('Locations service', () => {
         expect(await serviceCall(serviceCallName)('token', 'KEY')).toEqual('description')
       })
 
-      it('only calls the api once per request', async () => {
+      it('calls the api every time (caching is handled by redis)', async () => {
         await serviceCall(serviceCallName)('token', 'TYPE')
         await serviceCall(serviceCallName)('token', 'TYPE')
         await serviceCall(serviceCallName)('token', 'TYPE')
 
         expect(locationsApiClient.constants[apiCallName]).toHaveBeenCalledWith('token')
-        expect(locationsApiClient.constants[apiCallName]).toHaveBeenCalledTimes(1)
+        expect(locationsApiClient.constants[apiCallName]).toHaveBeenCalledTimes(3)
       })
     })
   }

--- a/server/services/locationsService.ts
+++ b/server/services/locationsService.ts
@@ -4,16 +4,10 @@ import LocationsApiClient from '../data/locationsApiClient'
 export default class LocationsService {
   constructor(private readonly locationsApiClient: LocationsApiClient) {}
 
-  private constantDataMaps: { [key: string]: { [key: string]: string } } = {}
-
   private async getConstantDataMap(token: string, apiCallName: keyof LocationsApiClient['constants']) {
-    if (!this.constantDataMaps[apiCallName]) {
-      this.constantDataMaps[apiCallName] = Object.fromEntries(
-        Object.values(await this.locationsApiClient.constants[apiCallName](token))[0].map(i => [i.key, i.description]),
-      )
-    }
-
-    return this.constantDataMaps[apiCallName]
+    return Object.fromEntries(
+      Object.values(await this.locationsApiClient.constants[apiCallName](token))[0].map(i => [i.key, i.description]),
+    )
   }
 
   async convertCellToNonResCell(


### PR DESCRIPTION
We thought that the service was spawned once pre request, but it is actually a long-lived object so this code would cause the constant values to be kept in memory until pod restart, so any new values would never be retrieved. Instead we will remove this code and let Redis handle the caching.

MAP-1489