### PR TITLE
Map 1679 add reason description to inactive cell list

### DIFF
--- a/integration_tests/e2e/inactiveCells/index.cy.ts
+++ b/integration_tests/e2e/inactiveCells/index.cy.ts
@@ -70,6 +70,7 @@ context('Inactive Cells Index', () => {
             capacity: { maxCapacity: 3, workingCapacity: 1 },
             status: 'INACTIVE',
             deactivatedReason: 'TEST1',
+            deactivationReasonDescription: 'TEST1 REASON DESCRIPTION',
             proposedReactivationDate: new Date(2023, 3, 14).toISOString(),
             planetFmReference: 'FM-1234321',
           }),
@@ -82,6 +83,7 @@ context('Inactive Cells Index', () => {
             capacity: { maxCapacity: 3, workingCapacity: 1 },
             status: 'INACTIVE',
             deactivatedReason: 'TEST1',
+            deactivationReasonDescription: '',
             proposedReactivationDate: new Date(2024, 2, 1).toISOString(),
             planetFmReference: undefined,
           }),
@@ -114,6 +116,45 @@ context('Inactive Cells Index', () => {
         cy.get('h1').contains('Inactive cells (3)')
 
         testInactiveCellsTable(inactiveCellsIndexPage, locations)
+      })
+
+      it('Displays both the reason and reason description values when it is present in the data', () => {
+        cy.signIn()
+        const indexPage = Page.verifyOnPage(IndexPage)
+
+        indexPage.cards.inactiveCells().find('a').click()
+        Page.verifyOnPage(InactiveCellsIndexPage)
+
+        cy.title().should('eq', 'View all inactive cells - Residential locations')
+        cy.get('h1').contains('Inactive cells (3)')
+
+        cy.get('.govuk-table__body > :nth-child(1) > :nth-child(2)').contains('Test type 1 - TEST1 REASON DESCRIPTION')
+      })
+
+      it('Displays only the reason when a reason description is an empty string value', () => {
+        cy.signIn()
+        const indexPage = Page.verifyOnPage(IndexPage)
+
+        indexPage.cards.inactiveCells().find('a').click()
+        Page.verifyOnPage(InactiveCellsIndexPage)
+
+        cy.title().should('eq', 'View all inactive cells - Residential locations')
+        cy.get('h1').contains('Inactive cells (3)')
+
+        cy.get('.govuk-table__body > :nth-child(2) > :nth-child(2)').contains('Test type 1')
+      })
+
+      it('Displays only the reason when a reason description value is not present in the data', () => {
+        cy.signIn()
+        const indexPage = Page.verifyOnPage(IndexPage)
+
+        indexPage.cards.inactiveCells().find('a').click()
+        Page.verifyOnPage(InactiveCellsIndexPage)
+
+        cy.title().should('eq', 'View all inactive cells - Residential locations')
+        cy.get('h1').contains('Inactive cells (3)')
+
+        cy.get('.govuk-table__body > :nth-child(3) > :nth-child(2)').contains('Test type 1')
       })
     })
 

--- a/server/views/pages/inactiveCells/index.njk
+++ b/server/views/pages/inactiveCells/index.njk
@@ -81,9 +81,15 @@
                </div>'
     }), row) %}
   {% endif %}
+  {% if cell.deactivationReasonDescription %}
+    {% set deactivationDescription = ' - ' + cell.deactivationReasonDescription %}
+  {% else %}
+    {% set deactivationDescription = '' %}
+  {% endif %}
+
   {% set row = (row.push(
     { html: "<a href='/view-and-update-locations/" + cell.prisonId + "/" + cell.id + "'>" + cell.pathHierarchy + "</a>", classes: 'govuk-table__header' },
-    { text: cell.deactivatedReason },
+    { text: cell.deactivatedReason + deactivationDescription },
     { text: (cell.proposedReactivationDate | formatDate) or 'Not provided' },
     { text: cell.planetFmReference or 'Not provided' },
     { text: cell.deactivatedBy }


### PR DESCRIPTION
The changes made in this PR cover the requirements detailed within [MAP-1679](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-1679).

- Updated view to display reason description data when it is available
- Added supporting e2e tests

**Screenshot**

<img width="1260" alt="Screenshot 2024-10-15 at 10 15 03" src="https://github.com/user-attachments/assets/e15019a4-a409-4d1b-95d3-369fcd815b45">


[MAP-1679]: https://dsdmoj.atlassian.net/browse/MAP-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ