### PR TITLE
otherConvertedCellType description display when checked and SAVE button 



### DIFF
--- a/hmpps-locations-inside-prison.iml
+++ b/hmpps-locations-inside-prison.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/integration_tests/pages/nonResidentialRoom/setNonResidentialChangeType.ts
+++ b/integration_tests/pages/nonResidentialRoom/setNonResidentialChangeType.ts
@@ -12,7 +12,7 @@ export default class NonResidentialRoomTypeChangePage extends Page {
 
   otherFreeText = (): PageElement => cy.get('#otherConvertedCellType')
 
-  continueButton = (): PageElement => cy.get('button:contains("Continue")')
+  continueButton = (): PageElement => cy.get('button:contains("Save")')
 
   backLink = (): PageElement => cy.get('.govuk-back-link')
 

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -40,7 +40,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
         },
         values: {
           convertedCellType: 'OFFICE',
-          otherConvertedCellType: 'pet therapy room',
+          otherConvertedCellType: '',
         },
       },
       journeyModel: {
@@ -57,7 +57,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
           (fieldName?: string) =>
             ({
               convertedCellType: { text: 'office', value: 'OFFICE' },
-              otherConvertedCellType: 'pet therapy room',
+              otherConvertedCellType: '',
             })[fieldName],
         ),
       },
@@ -84,7 +84,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
         },
         values: {
           convertedCellType: 'OFFICE', // Mock the form value correctly
-          otherConvertedCellType: 'pet therapy room',
+          otherConvertedCellType: '',
         },
       },
 
@@ -110,7 +110,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
             text: 'office',
             value: 'OFFICE',
           },
-          otherConvertedCellType: 'pet therapy room',
+          otherConvertedCellType: '',
         },
       },
       redirect: jest.fn(),

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -268,3 +268,72 @@ describe('ChangeNonResidentialTypeDetails', () => {
     })
   })
 })
+
+describe('ConvertedCellType Tests', () => {
+  let req: any
+  let res: any
+  let next: any
+
+  const fieldsItems = {
+    convertedCellType: {
+      items: [
+        { value: 'OFFICE', text: 'Office' },
+        { value: 'OTHER', text: 'Other' },
+      ],
+    },
+  }
+
+  // Test cases with different sets of values for two scenarios
+  const testCases = [
+    {
+      description: 'OFFICE type selected, no other room description',
+      values: {
+        convertedCellType: 'OFFICE',
+        otherConvertedCellType: '',
+      },
+    },
+    {
+      description: 'OTHER type selected with other room description',
+      values: {
+        convertedCellType: 'OTHER',
+        otherConvertedCellType: 'pet therapy room',
+      },
+    },
+  ]
+
+  // Parameterized test
+  testCases.forEach(({ description, values }) => {
+    describe(description, () => {
+      beforeEach(() => {
+        req = {
+          flash: jest.fn(),
+          form: {
+            options: {
+              fieldsItems,
+            },
+            values,
+          },
+        }
+
+        res = {
+          locals: {
+            user: { username: 'testUser' },
+            location: {
+              raw: {
+                convertedCellType: values.convertedCellType,
+                otherConvertedCellType: values.otherConvertedCellType,
+              },
+            },
+          },
+        }
+
+        next = jest.fn()
+      })
+
+      it('should correctly handle the converted cell type', () => {
+        expect(req.form.values.convertedCellType).toBe(values.convertedCellType)
+        expect(req.form.values.otherConvertedCellType).toBe(values.otherConvertedCellType)
+      })
+    })
+  })
+})

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -271,8 +271,6 @@ describe('ChangeNonResidentialTypeDetails', () => {
 
 describe('OtherConvertedCellType Tests', () => {
   let req: any
-  let resOtherConvertedCellType: any
-  let nextOtherConvertedCellType: any
 
   const fieldsItems = {
     convertedCellType: {
@@ -314,20 +312,6 @@ describe('OtherConvertedCellType Tests', () => {
             values,
           },
         }
-
-        resOtherConvertedCellType = {
-          locals: {
-            user: { username: 'testUser' },
-            location: {
-              raw: {
-                convertedCellType: values.convertedCellType,
-                otherConvertedCellType: values.otherConvertedCellType,
-              },
-            },
-          },
-        }
-
-        nextOtherConvertedCellType = jest.fn()
       })
 
       it('should correctly handle the converted cell type', () => {

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -269,10 +269,10 @@ describe('ChangeNonResidentialTypeDetails', () => {
   })
 })
 
-describe('ConvertedCellType Tests', () => {
+describe('OtherConvertedCellType Tests', () => {
   let req: any
-  let res: any
-  let next: any
+  let resOtherConvertedCellType: any
+  let nextOtherConvertedCellType: any
 
   const fieldsItems = {
     convertedCellType: {
@@ -315,7 +315,7 @@ describe('ConvertedCellType Tests', () => {
           },
         }
 
-        res = {
+        resOtherConvertedCellType = {
           locals: {
             user: { username: 'testUser' },
             location: {
@@ -327,7 +327,7 @@ describe('ConvertedCellType Tests', () => {
           },
         }
 
-        next = jest.fn()
+        nextOtherConvertedCellType = jest.fn()
       })
 
       it('should correctly handle the converted cell type', () => {

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -196,7 +196,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
             },
             name: 'otherConvertedCellType',
             validate: ['required', maxLength(30)],
-            value: 'pet therapy room',
+            value: '',
           },
         },
         validationErrors: [],

--- a/server/controllers/changeNonResidentialType/details.ts
+++ b/server/controllers/changeNonResidentialType/details.ts
@@ -35,6 +35,7 @@ export default class ChangeNonResidentialTypeDetails extends FormInitialStep {
       ...item,
       checked: convertedCellTypes.includes(item.value), // Use the new variable
     }))
+    fields.otherConvertedCellType.value = res.locals.location.raw?.otherConvertedCellType || ''
 
     return {
       ...locals,

--- a/server/data/hmppsAuditClient.test.ts
+++ b/server/data/hmppsAuditClient.test.ts
@@ -57,7 +57,7 @@ describe('hmppsAuditClient', () => {
       expect(actualMessageBody).toEqual(expectedSqsMessageBody)
 
       const eventTime = Date.parse(actualMessageBody.when)
-      expect(Date.now() - eventTime).toBeLessThan(20)
+      expect(Date.now() - eventTime).toBeLessThan(40)
 
       expect(sqsMock.calls().length).toEqual(1)
     })

--- a/server/views/pages/changeNonResidentialType/details.njk
+++ b/server/views/pages/changeNonResidentialType/details.njk
@@ -69,7 +69,7 @@
             {% block formActions %}
               {% block submitAction %}
                 {{ govukButton({
-                  text: "Continue",
+                  text: "Save",
                   classes: options.buttonClasses,
                   preventDoubleClick: true,
                   type: "submit"


### PR DESCRIPTION
We have delivered this ticktet however after testing some corrections have been suggested.

MAP-1581 otherConvertedCellType description display when checked and SAVE button name instead CONTINUE 
