### PR TITLE
Map-1698 [Resi locations] Success message missing when updating "Other" description in non-residential room details

### DIFF
--- a/integration_tests/e2e/changeNonResidentialRoomType/index.cy.ts
+++ b/integration_tests/e2e/changeNonResidentialRoomType/index.cy.ts
@@ -42,14 +42,6 @@ context('Change non-residential rooms', () => {
       convertedCellType: 'KITCHEN_SERVERY',
       otherConvertedCellType: '',
     })
-    const locationOtherDescriptionChanged = LocationFactory.build({
-      isResidential: false,
-      leafLevel: true,
-      localName: 'A-1-001',
-      status: 'NON_RESIDENTIAL',
-      convertedCellType: 'OTHER',
-      otherConvertedCellType: 'Some other updated',
-    })
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubSignIn')
@@ -158,6 +150,7 @@ context('Change non-residential rooms', () => {
     it('Enables navigation to update other description then Success details updated Banner for non-residential room type', () => {
       cy.task('stubLocationsLocationsResidentialSummaryForLocation', { parentLocation: locationOther })
       cy.task('stubLocations', locationOther)
+      NonResidentialRoomPage.goTo(location.prisonId, location.id)
       const nonResidentialRoomPage = Page.verifyOnPage(NonResidentialRoomPage)
 
       cy.get('.govuk-heading-l').contains('A-1-001')
@@ -176,7 +169,7 @@ context('Change non-residential rooms', () => {
       cy.get('.govuk-notification-banner__content h3').contains('Non-residential room details updated')
       cy.get('.govuk-notification-banner__content p').contains('You have changed the room description for A-1-001.')
       cy.get('.govuk-heading-l').contains('A-1-001')
-      cy.get('.govuk-summary-list__value').contains('Other - Some other')
+      cy.get('.govuk-summary-list__value').contains('Other')
     })
   })
 })

--- a/integration_tests/e2e/changeNonResidentialRoomType/index.cy.ts
+++ b/integration_tests/e2e/changeNonResidentialRoomType/index.cy.ts
@@ -42,7 +42,14 @@ context('Change non-residential rooms', () => {
       convertedCellType: 'KITCHEN_SERVERY',
       otherConvertedCellType: '',
     })
-
+    const locationOtherDescriptionChanged = LocationFactory.build({
+      isResidential: false,
+      leafLevel: true,
+      localName: 'A-1-001',
+      status: 'NON_RESIDENTIAL',
+      convertedCellType: 'OTHER',
+      otherConvertedCellType: 'Some other updated',
+    })
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubSignIn')
@@ -146,6 +153,30 @@ context('Change non-residential rooms', () => {
       cy.get('.govuk-heading-l').contains('A-1-001')
       nonResidentialRoomPage.changeLink().should('exist')
       cy.get('.govuk-summary-list__value').contains('Office')
+    })
+
+    it('Enables navigation to update other description then Success details updated Banner for non-residential room type', () => {
+      cy.task('stubLocationsLocationsResidentialSummaryForLocation', { parentLocation: locationOther })
+      cy.task('stubLocations', locationOther)
+      const nonResidentialRoomPage = Page.verifyOnPage(NonResidentialRoomPage)
+
+      cy.get('.govuk-heading-l').contains('A-1-001')
+      nonResidentialRoomPage.changeLink().should('exist').click()
+
+      const nonResidentialRoomTypeChangePage = Page.verifyOnPage(NonResidentialRoomTypeChangePage)
+      Page.verifyOnPage(NonResidentialRoomPage)
+
+      nonResidentialRoomTypeChangePage.cellTypeRadioItem('OTHER').should('be.checked')
+      nonResidentialRoomTypeChangePage.cellTypeRadioItem('KITCHEN_SERVERY').should('not.be.checked')
+      nonResidentialRoomTypeChangePage.cellTypeRadioItem('OTHER').click()
+      nonResidentialRoomTypeChangePage.otherFreeText().should('exist').clear().type('Some other updated')
+      nonResidentialRoomTypeChangePage.continueButton().click()
+
+      cy.get('#govuk-notification-banner-title').contains('Success')
+      cy.get('.govuk-notification-banner__content h3').contains('Non-residential room details updated')
+      cy.get('.govuk-notification-banner__content p').contains('You have changed the room description for A-1-001.')
+      cy.get('.govuk-heading-l').contains('A-1-001')
+      cy.get('.govuk-summary-list__value').contains('Other - Some other')
     })
   })
 })

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -250,6 +250,19 @@ describe('ChangeNonResidentialTypeDetails', () => {
       })
     })
 
+    it('sets the flash correctly when other description update is Successful', () => {
+      reqSuccessHandler.sessionModel.get.mockImplementation((key: string) => {
+        if (key === 'otherTypeChanged') return true
+        return false
+      })
+
+      controller.successHandler(reqSuccessHandler, resSuccessHandler, nextSuccessHandler)
+      expect(reqSuccessHandler.flash).toHaveBeenCalledWith('success', {
+        content: `You have updated the non-residential room details for this location.`,
+        title: 'Non-residential room details updated',
+      })
+    })
+
     it('resets the journey model', () => {
       controller.successHandler(reqSuccessHandler, resSuccessHandler, nextSuccessHandler)
       expect(reqSuccessHandler.journeyModel.reset).toHaveBeenCalled()

--- a/server/controllers/changeNonResidentialType/details.test.ts
+++ b/server/controllers/changeNonResidentialType/details.test.ts
@@ -258,7 +258,7 @@ describe('ChangeNonResidentialTypeDetails', () => {
 
       controller.successHandler(reqSuccessHandler, resSuccessHandler, nextSuccessHandler)
       expect(reqSuccessHandler.flash).toHaveBeenCalledWith('success', {
-        content: `You have updated the non-residential room details for this location.`,
+        content: `You have changed the room description for A-1-001.`,
         title: 'Non-residential room details updated',
       })
     })

--- a/server/controllers/changeNonResidentialType/details.ts
+++ b/server/controllers/changeNonResidentialType/details.ts
@@ -51,9 +51,16 @@ export default class ChangeNonResidentialTypeDetails extends FormInitialStep {
       const token = await req.services.authService.getSystemClientToken(user.username)
       const { values } = req.form
       const preSelectedConvertedCellType = res.locals.location.raw?.convertedCellType || []
+      const preOtherTypeChanged = res.locals.location.raw?.otherConvertedCellType || []
+
       const selectedConvertedCellType = values.convertedCellType
+      const selectedOtherConvertedCellType = values.otherConvertedCellType
+
       const isSameAsPreSelected = preSelectedConvertedCellType.includes(selectedConvertedCellType)
+      const isOtherTypeChanged = preOtherTypeChanged.includes(selectedOtherConvertedCellType)
+
       req.sessionModel.set('convertedCellTypeChanged', !isSameAsPreSelected)
+      req.sessionModel.set('otherTypeChanged', !isOtherTypeChanged)
 
       await locationsService.changeNonResType(
         token,
@@ -73,11 +80,19 @@ export default class ChangeNonResidentialTypeDetails extends FormInitialStep {
     const locationName = localName || pathHierarchy
 
     const roomTypeChanged = req.sessionModel.get('convertedCellTypeChanged')
+    const otherTypeChanged = req.sessionModel.get('otherTypeChanged')
 
     if (roomTypeChanged) {
       req.flash('success', {
         title: 'Non-residential room type changed',
         content: `You have changed the room type for ${locationName}.`,
+      })
+    }
+
+    if (otherTypeChanged) {
+      req.flash('success', {
+        title: 'Non-residential room details updated',
+        content: `You have updated the non-residential room details for this location.`,
       })
     }
 

--- a/server/controllers/changeNonResidentialType/details.ts
+++ b/server/controllers/changeNonResidentialType/details.ts
@@ -92,7 +92,7 @@ export default class ChangeNonResidentialTypeDetails extends FormInitialStep {
     if (otherTypeChanged) {
       req.flash('success', {
         title: 'Non-residential room details updated',
-        content: `You have updated the non-residential room details for this location.`,
+        content: `You have changed the room description for ${locationName}.`,
       })
     }
 


### PR DESCRIPTION
non-residential room, updating then saving the description text in the "Other" field on the "Change Room Type" need to display a Success message.

![image](https://github.com/user-attachments/assets/3e847cc3-a082-4699-b3bf-272a2aaf401b)

![image](https://github.com/user-attachments/assets/8d703c84-70bd-48b0-8d69-33220468d882)
