### PR TITLE
MAP-1732: Add crossorigin attribute to GTM script

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -30,7 +30,7 @@
 
   {% if googleTagManagerContainerId %}
     <!-- Google Tag Manager -->
-    <script nonce="{{ cspNonce }}">(function(w, d, s, l, i) {
+    <script nonce="{{ cspNonce }}" crossorigin>(function(w, d, s, l, i) {
         w[l] = w[l] || []
         w[l].push({
           'gtm.start':


### PR DESCRIPTION
I'm not sure if this will work or not but currently tag manager is having some issues due to COEP policy.

MAP-1732