### PR TITLE
MAP-1696 🐛  Error validation issues

### DIFF
--- a/server/controllers/cellConversion/setCellType.ts
+++ b/server/controllers/cellConversion/setCellType.ts
@@ -36,6 +36,9 @@ export default class CellConversionSetCellType extends FormInitialStep {
       }))
     }
 
+    if (specialistCellTypes !== undefined && specialistCellTypes !== (req.body.usedForTypes || []))
+      req.sessionModel.unset('specialistCellTypes')
+
     return {
       ...locals,
       buttonText: 'Continue',

--- a/server/controllers/cellConversion/usedFor.ts
+++ b/server/controllers/cellConversion/usedFor.ts
@@ -30,6 +30,9 @@ export default class CellConversionUsedFor extends FormInitialStep {
       }))
     }
 
+    if (usedForTypes !== undefined && usedForTypes !== (req.body.usedForTypes || []))
+      req.sessionModel.unset('usedForTypes')
+
     return {
       ...locals,
       cancelLink: `/view-and-update-locations/${prisonId}/${locationId}`,


### PR DESCRIPTION
Error validation displays previous selections after deselection when converting non-residential to residential cell

need un unset the req.sessionModel for the checked box for usedForType and specialistForType