### PR TITLE
MAP-1700 fixed sticky footer so tight to bottom in non-training view

### DIFF
--- a/assets/scss/components/_sticky-footer.scss
+++ b/assets/scss/components/_sticky-footer.scss
@@ -1,7 +1,7 @@
 .sticky-footer {
   position: fixed;
   z-index: 1000;
-  bottom: 40px;
+  bottom: 0px;
   width: 100%;
 
   .sticky-select-action-bar {
@@ -60,6 +60,10 @@
       margin: 0;
     }
   }
+}
+
+.sticky-footer-sandbox {
+  bottom: 40px !important
 }
 
 .js-enabled .sticky-select-action-bar {

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -136,7 +136,11 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <div class="sticky-footer">
+   {% if sandbox %}
+     <div class="sticky-footer sticky-footer-sandbox">
+   {% else %}
+     <div class="sticky-footer">
+    {% endif %}
     {% block stickyFooterContent %}
     {% endblock %}
 


### PR DESCRIPTION
[Previous PR](https://github.com/ministryofjustice/hmpps-locations-inside-prison/pull/175) fixed the footer issue in training mode but left a bug in non-training (the blue bar was positioned too high)
This code change is a fix for that and position of blue bar is at the bottom of view in non-training mode

non-training view
<img width="1398" alt="Screenshot 2024-10-29 at 08 53 05" src="https://github.com/user-attachments/assets/6a3931a3-8fd9-499e-8632-e417660e6e95">

training view 
<img width="1460" alt="Screenshot 2024-10-29 at 08 53 54" src="https://github.com/user-attachments/assets/00db7ba6-149f-4f98-bf0b-d995fe2875d4">
