### PR TITLE
MAP-1697: Make sure that the fields are pre-populated for change cell type

### DIFF
--- a/integration_tests/e2e/setCellType/index.cy.ts
+++ b/integration_tests/e2e/setCellType/index.cy.ts
@@ -230,14 +230,32 @@ context('Set cell type', () => {
         viewLocationsShowPage.changeSpecificCellTypeLink().should('not.exist')
       })
 
+      it('starts with the existing types checked', () => {
+        SetCellTypePage.goTo('7e570000-0000-0000-0000-000000000001')
+        const setCellTypePage = Page.verifyOnPage(SetCellTypePage)
+        setCellTypePage.cellTypeCheckbox('BIOHAZARD_DIRTY_PROTEST').should('be.checked')
+      })
+
       it('shows the correct validation error when nothing is selected', () => {
         SetCellTypePage.goTo('7e570000-0000-0000-0000-000000000001')
         const setCellTypePage = Page.verifyOnPage(SetCellTypePage)
+        setCellTypePage.cellTypeCheckbox('BIOHAZARD_DIRTY_PROTEST').click()
+        setCellTypePage.cellTypeCheckbox('BIOHAZARD_DIRTY_PROTEST').should('not.be.checked')
         setCellTypePage.saveCellTypeButton().click()
 
         cy.get('.govuk-error-summary__title').contains('There is a problem')
         cy.get('.govuk-error-summary__list').contains('Select a cell type')
         cy.get('#specialistCellTypes-error').contains('Select a cell type')
+      })
+
+      it('does not show the success banner when no change is made', () => {
+        SetCellTypePage.goTo('7e570000-0000-0000-0000-000000000001')
+        const setCellTypePage = Page.verifyOnPage(SetCellTypePage)
+        setCellTypePage.cellTypeCheckbox('BIOHAZARD_DIRTY_PROTEST').should('be.checked')
+        setCellTypePage.saveCellTypeButton().click()
+
+        Page.verifyOnPage(ViewLocationsShowPage)
+        cy.get('#govuk-notification-banner-title').should('not.exist')
       })
 
       it('shows the success banner when the change is complete', () => {

--- a/server/controllers/setCellType/index.test.ts
+++ b/server/controllers/setCellType/index.test.ts
@@ -33,6 +33,14 @@ describe('SetCellType', () => {
     },
   ]
 
+  const location = LocationFactory.build({
+    specialistCellTypes: ['Biohazard / dirty protest cell'],
+  })
+  location.raw = {
+    ...location,
+    specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+  }
+
   beforeEach(() => {
     req = {
       flash: jest.fn(),
@@ -63,9 +71,7 @@ describe('SetCellType', () => {
     res = {
       locals: {
         errorlist: [],
-        location: LocationFactory.build({
-          specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
-        }),
+        location,
         options: {
           fields,
         },
@@ -125,7 +131,7 @@ describe('SetCellType', () => {
   })
 
   describe('locals', () => {
-    it('returns the expected locals', () => {
+    it('returns the expected locals when there are errors', () => {
       res.locals.errorlist = [
         {
           key: 'specialistCellTypes',
@@ -147,6 +153,80 @@ describe('SetCellType', () => {
             text: 'Select a cell type',
           },
         ],
+      })
+    })
+
+    it('returns the expected locals when there are existing cell types', () => {
+      const checkboxFields = {
+        specialistCellTypes: {
+          items: [
+            {
+              hint: {
+                text: 'Also known as wheelchair accessible or Disability and Discrimination Act (DDA) compliant',
+              },
+              text: 'Accessible cell',
+              value: 'ACCESSIBLE_CELL',
+            },
+            {
+              hint: {
+                text: 'Previously known as a dirty protest cell',
+              },
+              text: 'Biohazard / dirty protest cell',
+              value: 'BIOHAZARD_DIRTY_PROTEST',
+            },
+            {
+              text: 'Constant Supervision Cell',
+              value: 'CONSTANT_SUPERVISION',
+            },
+          ],
+        },
+      }
+      req.form.values = {}
+      res.locals.fields = checkboxFields
+
+      const result = controller.locals(req, res)
+
+      expect(result).toEqual({
+        backLink: '/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001',
+        cancelLink: '/view-and-update-locations/TST/7e570000-0000-0000-0000-000000000001',
+        fields: {
+          specialistCellTypes: {
+            component: 'govukCheckboxes',
+            multiple: true,
+            validate: ['required'],
+            errorMessages: { required: 'Select a cell type' },
+            id: 'specialistCellTypes',
+            name: 'specialistCellTypes',
+            label: { text: 'Set specific cell type' },
+            hint: { text: 'Select all that apply.' },
+            items: [
+              {
+                text: 'Accessible cell',
+                value: 'ACCESSIBLE_CELL',
+                hint: {
+                  text: 'Also known as wheelchair accessible or Disability and Discrimination Act (DDA) compliant',
+                },
+                checked: false,
+              },
+              {
+                text: 'Biohazard / dirty protest cell',
+                value: 'BIOHAZARD_DIRTY_PROTEST',
+                hint: { text: 'Previously known as a dirty protest cell' },
+                checked: true,
+              },
+              {
+                text: 'Constant Supervision Cell',
+                value: 'CONSTANT_SUPERVISION',
+                hint: { text: undefined },
+                checked: false,
+              },
+            ],
+            value: ['CAT_A'],
+            errorMessage: { text: 'Select a cell type', href: '#specialistCellTypes' },
+          },
+        },
+        pageTitleText: 'Change specific cell type',
+        validationErrors: [],
       })
     })
   })

--- a/server/controllers/setCellType/index.ts
+++ b/server/controllers/setCellType/index.ts
@@ -33,7 +33,7 @@ export default class SetCellType extends FormInitialStep {
     if (!req.form.values?.specialistCellTypes) {
       fields.specialistCellTypes.items = fields.specialistCellTypes.items.map((item: FormWizard.Field) => ({
         ...item,
-        checked: location.specialistCellTypes.includes(item.value),
+        checked: location.raw.specialistCellTypes.includes(item.value),
       }))
     }
 
@@ -52,7 +52,7 @@ export default class SetCellType extends FormInitialStep {
     const { location } = res.locals
     const { id: locationId, prisonId } = location
 
-    if (isEqual(sortBy(req.form.values.specialistCellTypes), sortBy(location.specialistCellTypes))) {
+    if (isEqual(sortBy(req.form.values.specialistCellTypes), sortBy(location.raw.specialistCellTypes))) {
       return res.redirect(`/view-and-update-locations/${prisonId}/${locationId}`)
     }
 

--- a/server/data/types/locationsApi/location.d.ts
+++ b/server/data/types/locationsApi/location.d.ts
@@ -62,4 +62,5 @@ export declare interface Location {
   planetFmReference: string
   numberOfCellLocations: number
   oldWorkingCapacity: number
+  raw?: Location
 }


### PR DESCRIPTION
- Make sure boxes are checked if cell types already exist
- Don't show success banner if nothing has changed

These were both regressions caused by changing the middleware so that it decorates the location. Unfortunately this slipped through holes in my earlier test coverage so I have added more tests to prevent further regressions.

MAP-1697