### PR TITLE
MAP-1740 fixed date bugs

### DIFF
--- a/server/controllers/base/formInitialStep.ts
+++ b/server/controllers/base/formInitialStep.ts
@@ -226,7 +226,7 @@ export default class FormInitialStep extends FormWizard.Controller {
           const day = req.body[`${id}-day`]
           const month = req.body[`${id}-month`]
           const year = req.body[`${id}-year`]
-          const error = validateDateInput(day, month, year, values[id] as string)
+          const error = validateDateInput(day, month, year)
           if (error) {
             // eslint-disable-next-line no-param-reassign
             validationErrors[field.id] = this.formError(field.id, error)

--- a/server/controllers/base/formInitialStep.ts
+++ b/server/controllers/base/formInitialStep.ts
@@ -48,7 +48,7 @@ export default class FormInitialStep extends FormWizard.Controller {
       dateInvalid: `${fieldName} must be a real date`,
       dateInvalidDay: `${fieldName} must be a real date`,
       dateInvalidMonth: `${fieldName} must be a real date`,
-      dateInvalidYear: `${fieldName} must be a real date`,
+      dateInvalidYear: `Year must include 4 numbers`,
       dateMissingDay: `${fieldName} must include a day`,
       dateMissingDayAndMonth: `${fieldName} must include a day and month`,
       dateMissingDayAndYear: `${fieldName} must include a day and year`,

--- a/server/helpers/field/validateDateInput.test.ts
+++ b/server/helpers/field/validateDateInput.test.ts
@@ -1,18 +1,7 @@
 import validateDateInput from './validateDateInput'
 
 function test(day: string | number, month: string | number, year: string | number, error: string) {
-  expect(
-    validateDateInput(
-      day.toString(),
-      month.toString(),
-      year.toString(),
-      [
-        year,
-        month !== '' ? month.toString().padStart(2, '0') : '',
-        day !== '' ? day.toString().padStart(2, '0') : '',
-      ].join('-'),
-    ),
-  ).toBe(error)
+  expect(validateDateInput(day.toString(), month.toString(), year.toString())).toBe(error)
 }
 
 describe('Field helpers', () => {

--- a/server/helpers/field/validateDateInput.ts
+++ b/server/helpers/field/validateDateInput.ts
@@ -1,9 +1,4 @@
-export default function validateDateInput(
-  dayInputValue: string,
-  monthInputValue: string,
-  yearInputValue: string,
-  isoDate: string,
-) {
+export default function validateDateInput(dayInputValue: string, monthInputValue: string, yearInputValue: string) {
   const missingFields = []
   if (dayInputValue === '') {
     missingFields.push('Day')
@@ -21,7 +16,7 @@ export default function validateDateInput(
   const day = Number(dayInputValue)
   const month = Number(monthInputValue)
   const year = Number(yearInputValue)
-  const estimatedReactivationDate = new Date(isoDate as string)
+  const estimatedReactivationDate = new Date(year, month - 1, day)
   let invalidField: string
   if (
     !Number.isFinite(day) ||

--- a/server/helpers/field/validateDateInput.ts
+++ b/server/helpers/field/validateDateInput.ts
@@ -34,7 +34,7 @@ export default function validateDateInput(
   if (!Number.isFinite(month) || month <= 0 || month > 12) {
     invalidField = invalidField ? '*' : 'Month'
   }
-  if (!Number.isFinite(year)) {
+  if (!Number.isFinite(year) || yearInputValue.length < 4) {
     invalidField = invalidField ? '*' : 'Year'
   }
 

--- a/server/validators/dateTodayOrInFuture.test.ts
+++ b/server/validators/dateTodayOrInFuture.test.ts
@@ -1,28 +1,27 @@
-import { formatISO } from 'date-fns'
+import { startOfTomorrow, startOfToday, startOfYesterday } from 'date-fns'
 import dateTodayOrInFuture from './dateTodayOrInFuture'
 
 describe('dateTodayOrInFuture', () => {
   it('allows dates in the future', () => {
-    const date = new Date()
-    date.setHours(0)
-    date.setMinutes(0)
-    date.setDate(date.getDate() + 1)
-    expect(dateTodayOrInFuture(formatISO(date))).toEqual(true)
+    const tomorrow = startOfTomorrow()
+    const tomorrowAsString = `${tomorrow.getFullYear()}-${tomorrow.getMonth() + 1}-${tomorrow.getDate()}`
+    expect(dateTodayOrInFuture(tomorrowAsString)).toEqual(true)
   })
 
   it("allows today's date", () => {
-    const date = new Date()
-    date.setHours(0)
-    date.setMinutes(0)
-    date.setDate(date.getDate())
-    expect(dateTodayOrInFuture(formatISO(date))).toEqual(true)
+    const today = startOfToday()
+    const todayAsString = `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`
+    expect(dateTodayOrInFuture(todayAsString)).toEqual(true)
   })
 
-  it('forbids past dates', () => {
-    const date = new Date()
-    date.setHours(0)
-    date.setMinutes(0)
-    date.setDate(date.getDate() - 1)
-    expect(dateTodayOrInFuture(formatISO(date))).toEqual(false)
+  it('forbids recent past dates', () => {
+    const yesterday = startOfYesterday()
+    const yesterdayAsString = `${yesterday.getFullYear()}-${yesterday.getMonth() + 1}-${yesterday.getDate()}`
+    expect(dateTodayOrInFuture(yesterdayAsString)).toEqual(false)
+  })
+
+  it('forbids really old past dates', () => {
+    const reallyOldDate = '1066-1-10'
+    expect(dateTodayOrInFuture(reallyOldDate)).toEqual(false)
   })
 })

--- a/server/validators/dateTodayOrInFuture.ts
+++ b/server/validators/dateTodayOrInFuture.ts
@@ -1,7 +1,10 @@
+import { startOfToday } from 'date-fns'
+
 export default function dateTodayOrInFuture(value: string) {
-  const today = new Date()
-  today.setHours(0)
-  today.setMinutes(0)
-  today.setSeconds(0)
-  return value === '' || new Date(value).getTime() >= today.getTime()
+  const parsedDate = value.split('-')
+  const year = parseInt(parsedDate[0], 10)
+  const month = parseInt(parsedDate[1], 10) - 1
+  const date = parseInt(parsedDate[2], 10)
+  const dateInput = new Date(year, month, date)
+  return value === '' || dateInput >= startOfToday()
 }


### PR DESCRIPTION
[MAP-1740](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=5cd29c554326200dc971eab7&selectedIssue=MAP-1740)

Date input should not accept really old dates
Date input should accept today onwards
Date input Year must be at least 4 numbers long (added new validation message for this)

[MAP-1740]: https://dsdmoj.atlassian.net/browse/MAP-1740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ