### PR TITLE
MAP-1694 Update Archived locations page to display ‘Reason’

### DIFF
--- a/integration_tests/e2e/archivedLocations/index.cy.ts
+++ b/integration_tests/e2e/archivedLocations/index.cy.ts
@@ -125,5 +125,49 @@ context('Archived Locations Index', () => {
         archivedLocationsIndexPage.emptyStateMessage().should('exist')
       })
     })
+
+    context('When there are archived locations but permanentlyInactiveReason is not provided ', () => {
+      beforeEach(() => {
+        locations = [
+          LocationFactory.build({
+            id: '7e570000-0000-000a-0001-000000000001',
+            pathHierarchy: 'A-1-001',
+            localName: undefined,
+            code: '001',
+            inactiveCells: 1,
+            capacity: { maxCapacity: 3, workingCapacity: 1 },
+            status: 'INACTIVE',
+            deactivatedReason: 'TEST1',
+            permanentlyInactiveReason: undefined,
+            proposedReactivationDate: new Date(2023, 3, 14).toISOString(),
+            planetFmReference: 'FM-1234321',
+          }),
+        ]
+
+        cy.task('stubLocationsPrisonArchivedLocations', locations)
+      })
+
+      it('Correctly presents the API data', () => {
+        cy.signIn()
+        const indexPage = Page.verifyOnPage(IndexPage)
+
+        indexPage.cards.archivedLocations().find('a').click()
+        const archivedLocationsIndexPage = Page.verifyOnPage(ArchivedLocationsIndexPage)
+
+        cy.title().should('eq', 'Archived locations - Residential locations')
+
+        archivedLocationsIndexPage.locationsTable().should('exist')
+        archivedLocationsIndexPage.locationsTableRows().each((row, i) => {
+          const location = locations[i]
+          const cells = archivedLocationsIndexPage.locationsTableCells(row as unknown as PageElement)
+
+          cy.wrap(cells.location).contains(location.localName || location.pathHierarchy)
+          cy.wrap(cells.locationType).contains('Cell')
+          cy.wrap(cells.reason).contains('Not provided')
+          cy.wrap(cells.deactivatedBy).contains(`john smith on ${formatDate(location.deactivatedDate)}`)
+        })
+        archivedLocationsIndexPage.emptyStateMessage().should('not.exist')
+      })
+    })
   })
 })

--- a/integration_tests/e2e/archivedLocations/index.cy.ts
+++ b/integration_tests/e2e/archivedLocations/index.cy.ts
@@ -100,6 +100,7 @@ context('Archived Locations Index', () => {
 
           cy.wrap(cells.location).contains(location.localName || location.pathHierarchy)
           cy.wrap(cells.locationType).contains('Cell')
+          cy.wrap(cells.reason).contains('Demolished')
           cy.wrap(cells.deactivatedBy).contains(`john smith on ${formatDate(location.deactivatedDate)}`)
         })
         archivedLocationsIndexPage.emptyStateMessage().should('not.exist')

--- a/integration_tests/pages/archivedLocations/index.ts
+++ b/integration_tests/pages/archivedLocations/index.ts
@@ -15,7 +15,8 @@ export default class ArchivedLocationsIndexPage extends Page {
     return {
       location: children.eq(0),
       locationType: children.eq(1),
-      deactivatedBy: children.eq(2),
+      reason: children.eq(2),
+      deactivatedBy: children.eq(3),
     }
   }
 

--- a/server/views/pages/archivedLocations/index.njk
+++ b/server/views/pages/archivedLocations/index.njk
@@ -13,6 +13,7 @@
     [
       { text: location.pathHierarchy },
       { text: location.locationType },
+      { text: location.permanentlyInactiveReason  or "Not provided" },
       { text: location.deactivatedBy + ' on ' + (location.deactivatedDate | formatDate) }
     ]
   ), rows) %}
@@ -28,7 +29,8 @@
         head: [
           { text: "Location", classes: "govuk-!-width-one-sixth" },
           { text: "Location type", classes: "govuk-!-width-one-sixth" },
-          { text: "Archived by", classes: "govuk-!-width-four-sixths" }
+          { text: "Reason", classes: "govuk-!-width-two-sixths" },
+          { text: "Deactivated by", classes: "govuk-!-width-two-sixths" }
         ],
         rows: rows
       }) }}


### PR DESCRIPTION
Update Archived locations screen to display the ‘Reason’ value.

the table that lists all permanently inactive flagged locations in the establishment 

with the addition of a column heading ‘Reason’

and the new column ‘Reason’ displays the permanent deactivation/archive reason ID

and if the reason does not exist display the content ‘Not provided’ 

and reason column will appear after ‘Location type’ and before ‘Deactivated by’ 

