### PR TITLE
MAP-1773 added css to middle-align the location column of the table

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -171,3 +171,7 @@ $sticky-footer-vertical-spacing: govuk-spacing(2);
     }
   }
 }
+
+#locations-table tbody tr th {
+  vertical-align: middle
+}

--- a/server/views/macros/locationsTable.njk
+++ b/server/views/macros/locationsTable.njk
@@ -42,7 +42,8 @@
 
     {{ govukTable({
       attributes: {
-        "data-qa": "locations-table"
+        "data-qa": "locations-table",
+        "id": "locations-table"
       },
       caption: locationType,
       captionClasses: "govuk-table__caption--m",


### PR DESCRIPTION
[ MAP-1773](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=5cd29c554326200dc971eab7&selectedIssue=MAP-1773)

The contents of the location column in the table should be vertically  middle aligned

Now looks like this: 
<img width="1184" alt="Screenshot 2024-11-04 at 11 51 17" src="https://github.com/user-attachments/assets/d6d1a4ee-7c67-43e3-b32e-60167bd18c30">

