### PR TITLE
Clear inactive cells checkboxes after browser back button

### DIFF
--- a/assets/js/mojFrontendInit.js
+++ b/assets/js/mojFrontendInit.js
@@ -1,1 +1,13 @@
 window.MOJFrontend.initAll()
+
+// Disable autocomplete for the select all checkbox
+window.MOJFrontend.MultiSelect.prototype.getToggleHtml = function () {
+  var html = ''
+  html += '<div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">'
+  html += '  <input type="checkbox" class="govuk-checkboxes__input" id="checkboxes-all" autocomplete="off">'
+  html += '  <label class="govuk-label govuk-checkboxes__label moj-multi-select__toggle-label" for="checkboxes-all">'
+  html += '    <span class="govuk-visually-hidden">Select all</span>'
+  html += '  </label>'
+  html += '</div>'
+  return html
+}

--- a/integration_tests/e2e/reactivate/cells/index.cy.ts
+++ b/integration_tests/e2e/reactivate/cells/index.cy.ts
@@ -5,6 +5,7 @@ import ReactivateCellDetailsPage from '../../../pages/reactivate/cell/details'
 import ReactivateCellsCheckCapacityPage from '../../../pages/reactivate/cells/checkCapacity'
 import ReactivateCellsConfirmPage from '../../../pages/reactivate/cells/confirm'
 import ReactivateCellsChangeCapacityPage from '../../../pages/reactivate/cells/changeCapacity'
+import ViewLocationsShowPage from '../../../pages/viewLocations/show'
 
 context('Reactivate cells', () => {
   let locations: ReturnType<typeof LocationFactory.build>[]
@@ -208,6 +209,21 @@ context('Reactivate cells', () => {
 
         page.footerClearLink().click()
         page.footer().should('exist').should('not.be.visible')
+      })
+
+      it('unchecks the boxes when navigating away and then back using the browser back button', () => {
+        InactiveCellsIndexPage.goTo()
+        const inactiveCellsPage = Page.verifyOnPage(InactiveCellsIndexPage)
+        inactiveCellsPage.selectAllCheckbox().click({ force: true })
+        cy.get('a:contains("A-1-002")').click()
+        Page.verifyOnPage(ViewLocationsShowPage)
+        cy.go('back')
+        // wait for js to load
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000)
+        Page.verifyOnPage(InactiveCellsIndexPage)
+        cy.get('input:checked').should('not.exist')
+        cy.get('.sticky-select-action-bar--active').should('not.exist')
       })
     })
 

--- a/server/routes/changeTemporaryDeactivationDetails/fields.ts
+++ b/server/routes/changeTemporaryDeactivationDetails/fields.ts
@@ -29,6 +29,7 @@ const fields = {
       text: 'Describe deactivation reason',
     },
     nameForErrors: 'Deactivation reason',
+    autocomplete: 'off',
   },
   deactivationReasonDescription: {
     component: 'govukInput',
@@ -40,6 +41,7 @@ const fields = {
       text: 'Description (optional)',
     },
     nameForErrors: 'Description',
+    autocomplete: 'off',
   },
   estimatedReactivationDate: {
     component: 'govukDateInput',
@@ -68,6 +70,7 @@ const fields = {
       classes: 'govuk-label--m',
     },
     nameForErrors: 'Planet FM reference number',
+    autocomplete: 'off',
   },
 }
 

--- a/server/routes/removeLocalName/fields.ts
+++ b/server/routes/removeLocalName/fields.ts
@@ -8,6 +8,7 @@ const fields = {
       text: 'local name',
       classes: 'govuk-fieldset__legend--m',
     },
+    autocomplete: 'off',
   },
 }
 

--- a/server/views/pages/inactiveCells/index.njk
+++ b/server/views/pages/inactiveCells/index.njk
@@ -76,7 +76,7 @@
   {% if canAccess('reactivate') %}
     {% set row = (row.push({
       html: '<div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
-                 <input aria-label="' + cell.pathHierarchy + '" type="checkbox" class="govuk-checkboxes__input" name="selectedLocations" id="location-' + cell.id + '" value="' + cell.id + '">
+                 <input aria-label="' + cell.pathHierarchy + '" type="checkbox" class="govuk-checkboxes__input" name="selectedLocations" id="location-' + cell.id + '" value="' + cell.id + '" autocomplete="off">
                  <label class="govuk-label govuk-checkboxes__label moj-multi-select__toggle-label" for="location-' + cell.id + '"></label>
                </div>'
     }), row) %}


### PR DESCRIPTION
Disable autocomplete on various fields. This also fixes the back button issue.

MAP-1772