### PR TITLE
Update confirm.njk

### DIFF
--- a/server/views/pages/nonResidentialConversion/confirm.njk
+++ b/server/views/pages/nonResidentialConversion/confirm.njk
@@ -65,7 +65,7 @@
           <h2 class="govuk-heading-m">Change to establishment capacity</h2>
 
           {{ govukWarningText({
-            text: "This cell will be decertified",
+            text: "This cell will be decertified.",
             iconFallbackText: "Warning",
             classes: "govuk-!-margin-bottom-5"
           }) }}


### PR DESCRIPTION
Added a full stop that was missing from the warning message when a cell is converted into a non-res room.