### PR TITLE
MAP-2588 Add splash screen functionality for prison module management.

### DIFF
--- a/integration_tests/e2e/admin/index.cy.ts
+++ b/integration_tests/e2e/admin/index.cy.ts
@@ -41,6 +41,7 @@ context('Admin Index', () => {
       cy.task('stubDisplayHousingCheckboxesDisabled')
       cy.task('stubDisplayHousingCheckboxesPost')
       cy.task('stubGetSplashScreenCondition')
+      cy.task('stubCreateSplashScreenCondition')
       cy.task('stubUpdateSplashScreenCondition')
       cy.signIn()
     })
@@ -99,6 +100,9 @@ context('Admin Index', () => {
       cy.task('stubPrisonConfigurationDeactivateResi')
       cy.task('stubDisplayHousingCheckboxesEnabled')
       cy.task('stubDisplayHousingCheckboxesDelete')
+      cy.task('stubGetSplashScreenCondition')
+      cy.task('stubCreateSplashScreenCondition')
+      cy.task('stubUpdateSplashScreenCondition')
       cy.signIn()
     })
 

--- a/integration_tests/e2e/admin/index.cy.ts
+++ b/integration_tests/e2e/admin/index.cy.ts
@@ -40,6 +40,8 @@ context('Admin Index', () => {
       cy.task('stubPrisonConfigurationCertApproval')
       cy.task('stubDisplayHousingCheckboxesDisabled')
       cy.task('stubDisplayHousingCheckboxesPost')
+      cy.task('stubGetSplashScreenCondition')
+      cy.task('stubUpdateSplashScreenCondition')
       cy.signIn()
     })
 

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -1,4 +1,5 @@
 import { stubFor } from './wiremock'
+import { SplashCondition, SplashScreen } from '../../server/data/prisonApiClient'
 
 const stubPrisonHealthPing = () =>
   stubFor({
@@ -73,10 +74,72 @@ const stubDisplayHousingCheckboxesPost = (returnData: { prisonid: 'TST'; prison:
     jsonBody: returnData,
   })
 
+const stubGetSplashScreenCondition = (
+  prisonId: string = 'TST',
+  returnData: SplashCondition = { conditionType: 'CASELOAD', conditionValue: 'TST', blockAccess: false },
+) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPath: `/prison-api/api/splash-screen/OIDCHOLO/condition/CASELOAD/${prisonId}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      jsonBody: returnData,
+    },
+  })
+
+const sampleSplashResult = {
+  moduleName: 'OIDCHOLO',
+  conditions: [{ conditionType: 'CASELOAD', conditionValue: 'TST', blockAccess: false }],
+  warningText: 'WARN',
+  blockedText: 'BLOCKED',
+  blockAccessType: 'COND',
+}
+const stubCreateSplashScreenCondition = (returnData: SplashScreen = sampleSplashResult) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPath: '/prison-api/api/splash-screen/OIDCHOLO/condition',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      jsonBody: returnData,
+    },
+  })
+
+const stubUpdateSplashScreenCondition = (
+  prisonId: string = 'TST',
+  blockScreen: boolean = false,
+  returnData: SplashScreen = sampleSplashResult,
+) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      urlPattern: `/prison-api/api/splash-screen/OIDCHOLO/condition/CASELOAD/${prisonId}/${blockScreen}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      jsonBody: returnData,
+    },
+  })
+
 export default {
   stubPrisonHealthPing,
   stubDisplayHousingCheckboxesDisabled,
   stubDisplayHousingCheckboxesEnabled,
   stubDisplayHousingCheckboxesDelete,
   stubDisplayHousingCheckboxesPost,
+  stubGetSplashScreenCondition,
+  stubCreateSplashScreenCondition,
+  stubUpdateSplashScreenCondition,
 }

--- a/integration_tests/pages/admin/index.ts
+++ b/integration_tests/pages/admin/index.ts
@@ -19,6 +19,7 @@ export default class PrisonConfigurationIndexPage extends Page {
     cy.get('.govuk-summary-list__value').eq(3).contains('INACTIVE')
     cy.get('.govuk-summary-list__key').eq(4).contains('Prison non housing checkboxes')
     cy.get('.govuk-summary-list__key').eq(5).contains('OIDCHOLO screen blocked')
+    cy.get('.govuk-summary-list__value').eq(5).contains('Not-Blocked')
   }
 
   changeResiLink = (): PageElement => cy.get('.govuk-summary-list__actions').eq(0).contains('Change')

--- a/integration_tests/pages/admin/index.ts
+++ b/integration_tests/pages/admin/index.ts
@@ -18,6 +18,7 @@ export default class PrisonConfigurationIndexPage extends Page {
     cy.get('.govuk-summary-list__key').eq(3).contains('Certification approval required')
     cy.get('.govuk-summary-list__value').eq(3).contains('INACTIVE')
     cy.get('.govuk-summary-list__key').eq(4).contains('Prison non housing checkboxes')
+    cy.get('.govuk-summary-list__key').eq(5).contains('OIDCHOLO screen blocked')
   }
 
   changeResiLink = (): PageElement => cy.get('.govuk-summary-list__actions').eq(0).contains('Change')

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -124,6 +124,7 @@ interface TypedLocals {
   pathSuffix?: string
   prisonConfiguration?: PrisonConfiguration
   prisonNonHousingDisabled?: boolean
+  nomisScreenBlocked?: boolean
   prisonId?: string
   prisonerLocation?: PrisonerLocation
   prisonResidentialSummary?: PrisonResidentialSummary

--- a/server/controllers/admin/resi/confirm.ts
+++ b/server/controllers/admin/resi/confirm.ts
@@ -43,6 +43,16 @@ export default class ResiStatusChangeConfirm extends FormInitialStep {
         await prisonService.deactivatePrisonService(req.session.systemToken, prisonId, serviceCode)
       }
 
+      // block or unblock the screen
+      try {
+        await prisonService.getScreenStatus(req.session.systemToken, prisonId)
+        await prisonService.updateScreen(req.session.systemToken, prisonId, status === 'ACTIVE')
+      } catch (error) {
+        if (error.responseStatus === 404) {
+          await prisonService.addCondition(req.session.systemToken, prisonId, status === 'ACTIVE')
+        }
+      }
+
       analyticsService.sendEvent(req, 'resi_status', {
         prison_id: prisonId,
         status,

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -19,7 +19,7 @@ import HmppsAuditClient from './hmppsAuditClient'
 import LocationsApiClient from './locationsApiClient'
 import GoogleAnalyticsClient from './googleAnalyticsClient'
 import logger from '../../logger'
-import PrisonApiClient from './prisonApiClient'
+import { PrisonApiClient } from './prisonApiClient'
 
 export const dataAccess = () => {
   const hmppsAuthClient = new AuthenticationClient(

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -3,13 +3,28 @@ import BaseApiClient from './baseApiClient'
 import { RedisClient } from './redisClient'
 import config from '../config'
 import { ServiceCode } from './types/locationsApi/serviceCode'
+import { ModuleName } from './types/locationsApi/moduleName'
 
 export interface PrisonDetails {
   prisonId: string
   prison: string
 }
 
-export default class PrisonApiClient extends BaseApiClient {
+export interface SplashScreen {
+  moduleName: string
+  warningText: string
+  blockedText: string
+  blockAccessType: string
+  conditions: SplashCondition[]
+}
+
+export interface SplashCondition {
+  conditionType: string
+  conditionValue: string
+  blockAccess: boolean
+}
+
+export class PrisonApiClient extends BaseApiClient {
   constructor(
     protected readonly redisClient: RedisClient,
     authenticationClient: AuthenticationClient,
@@ -29,6 +44,33 @@ export default class PrisonApiClient extends BaseApiClient {
     deactivatePrisonService: this.apiCall<PrisonDetails, { serviceCode: ServiceCode; prisonId: string }>({
       path: '/api/agency-switches/:serviceCode/agency/:prisonId',
       requestType: 'delete',
+    }),
+  }
+
+  splashScreen = {
+    getScreenStatus: this.apiCall<SplashCondition, { moduleName: ModuleName; prisonId: string }>({
+      path: '/api/splash-screen/:moduleName/condition/CASELOAD/:prisonId',
+      requestType: 'get',
+    }),
+    addCondition: this.apiCall<
+      SplashScreen,
+      { moduleName: ModuleName; prisonId: string },
+      {
+        conditionType: string
+        conditionValue: string
+        blockAccess: boolean
+      }
+    >({
+      path: '/api/splash-screen/:moduleName/condition',
+      requestType: 'post',
+    }),
+    removeCondition: this.apiCall<SplashScreen, { moduleName: ModuleName; prisonId: string }>({
+      path: '/api/splash-screen/:moduleName/condition/CASELOAD/:prisonId',
+      requestType: 'delete',
+    }),
+    updateScreen: this.apiCall<SplashScreen, { moduleName: ModuleName; prisonId: string; blockScreen: string }>({
+      path: '/api/splash-screen/:moduleName/condition/CASELOAD/:prisonId/:blockScreen',
+      requestType: 'put',
     }),
   }
 }

--- a/server/data/types/locationsApi/moduleName.d.ts
+++ b/server/data/types/locationsApi/moduleName.d.ts
@@ -1,0 +1,1 @@
+export declare type ModuleName = 'OIDCHOLO'

--- a/server/middleware/getServicePrisonsNonHousingDisplay.ts
+++ b/server/middleware/getServicePrisonsNonHousingDisplay.ts
@@ -1,5 +1,7 @@
 import { type NextFunction, Request, type Response } from 'express'
+import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import logger from '../../logger'
+import PrisonService from '../services/prisonService'
 
 export default function getServicePrisonsNonHousingDisplay() {
   return async (req: Request, res: Response, next: NextFunction) => {
@@ -20,5 +22,52 @@ export default function getServicePrisonsNonHousingDisplay() {
         next(error)
       }
     }
+  }
+}
+
+export function getSplashScreenStatus() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const { systemToken } = req.session
+    const { prisonId } = res.locals
+
+    try {
+      res.locals.nomisScreenBlocked = await getScreenBlockStatus(req.services.prisonService, systemToken, prisonId)
+      next()
+    } catch (error) {
+      handleScreenStatusError(error, prisonId, next)
+    }
+  }
+}
+
+async function getScreenBlockStatus(prisonService: PrisonService, token: string, prisonId: string): Promise<boolean> {
+  try {
+    const condition = await prisonService.getScreenStatus(token, prisonId)
+    return condition.blockAccess
+  } catch (error) {
+    if (error.responseStatus === 404) {
+      return getFallbackScreenStatus(prisonService, token)
+    }
+    throw error
+  }
+}
+
+async function getFallbackScreenStatus(prisonService: PrisonService, token: string): Promise<boolean> {
+  try {
+    const condition = await prisonService.getScreenStatus(token, '**ALL**')
+    return condition.blockAccess
+  } catch (error) {
+    if (error.responseStatus === 404) {
+      return false
+    }
+    throw error
+  }
+}
+
+function handleScreenStatusError(error: SanitisedError, prisonId: string, next: NextFunction): void {
+  if (error.responseStatus !== 404) {
+    logger.error(error, `Failed to check splash screen for prisonId: ${prisonId}`)
+    next(error)
+  } else {
+    next()
   }
 }

--- a/server/routes/adminRouter.ts
+++ b/server/routes/adminRouter.ts
@@ -6,7 +6,9 @@ import validateCaseload from '../middleware/validateCaseload'
 import addBreadcrumb from '../middleware/addBreadcrumb'
 import populatePrisonConfiguration from '../middleware/populatePrisonConfiguration'
 import adminIndex from '../controllers/adminIndex'
-import getServicePrisonsNonHousingDisplay from '../middleware/getServicePrisonsNonHousingDisplay'
+import getServicePrisonsNonHousingDisplay, {
+  getSplashScreenStatus,
+} from '../middleware/getServicePrisonsNonHousingDisplay'
 import populatePrisonAndLocationId from '../middleware/populatePrisonAndLocationId'
 import redirectToAddPrisonId from '../middleware/redirectToAddPrisonId'
 
@@ -22,6 +24,7 @@ const controller = (services: Services) => {
     addBreadcrumb({ title: '', href: '/' }),
     populatePrisonConfiguration(),
     getServicePrisonsNonHousingDisplay(),
+    getSplashScreenStatus(),
     logPageView(services.auditService, Page.LOCATION_ADMIN),
     adminIndex,
   )

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,5 +1,5 @@
 import PrisonService from './prisonService'
-import PrisonApiClient from '../data/prisonApiClient'
+import { PrisonApiClient } from '../data/prisonApiClient'
 
 jest.mock('../data/prisonApiClient')
 

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,4 +1,4 @@
-import PrisonApiClient from '../data/prisonApiClient'
+import { PrisonApiClient } from '../data/prisonApiClient'
 import { ServiceCode } from '../data/types/locationsApi/serviceCode'
 
 export default class PrisonService {
@@ -14,5 +14,36 @@ export default class PrisonService {
 
   async deactivatePrisonService(token: string, prisonId: string, serviceCode: ServiceCode) {
     return this.prisonApiClient.servicePrisons.deactivatePrisonService(token, { prisonId, serviceCode })
+  }
+
+  async getScreenStatus(token: string, prisonId: string) {
+    return this.prisonApiClient.splashScreen.getScreenStatus(token, { prisonId, moduleName: 'OIDCHOLO' })
+  }
+
+  async addCondition(token: string, prisonId: string, block: boolean = true) {
+    return this.prisonApiClient.splashScreen.addCondition(
+      token,
+      {
+        prisonId,
+        moduleName: 'OIDCHOLO',
+      },
+      {
+        conditionType: 'CASELOAD',
+        conditionValue: `${prisonId}`,
+        blockAccess: block,
+      },
+    )
+  }
+
+  async removeCondition(token: string, prisonId: string) {
+    return this.prisonApiClient.splashScreen.removeCondition(token, { prisonId, moduleName: 'OIDCHOLO' })
+  }
+
+  async updateScreen(token: string, prisonId: string, block: boolean) {
+    return this.prisonApiClient.splashScreen.updateScreen(token, {
+      prisonId,
+      moduleName: 'OIDCHOLO',
+      blockScreen: block === true ? 'true' : 'false',
+    })
   }
 }

--- a/server/views/pages/admin/index.njk
+++ b/server/views/pages/admin/index.njk
@@ -22,6 +22,14 @@
   {% endif %}
 {% endset %}
 
+{% set screenBlocked %}
+  {% if nomisScreenBlocked %}
+    Blocked
+  {% else %}
+    Not-Blocked
+  {% endif %}
+{% endset %}
+
 {% block beforeContent %}
   {{ super() }}
 
@@ -108,6 +116,14 @@
           },
           value: {
             text: housingMessage
+          }
+        },
+        {
+          key: {
+          text: 'OIDCHOLO screen blocked'
+        },
+          value: {
+            text: screenBlocked
           }
         }
         ],

--- a/wiremock-docker/__files/splash-condition-ALL-result.json
+++ b/wiremock-docker/__files/splash-condition-ALL-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "**ALL**",
+  "blockAccess": false
+}

--- a/wiremock-docker/__files/splash-condition-BXI-result.json
+++ b/wiremock-docker/__files/splash-condition-BXI-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "BXI",
+  "blockAccess": true
+}

--- a/wiremock-docker/__files/splash-condition-MDI-result.json
+++ b/wiremock-docker/__files/splash-condition-MDI-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "MDI",
+  "blockAccess": true
+}

--- a/wiremock-docker/__files/splash-screen-result.json
+++ b/wiremock-docker/__files/splash-screen-result.json
@@ -1,0 +1,13 @@
+{
+  "moduleName": "OIDCHOLO",
+  "warningText": "Access to this screen will soon be revoked",
+  "blockedText": "You can not longer use this screen, use DPS",
+  "blockAccessType": "NO",
+  "conditions": [
+    {
+      "conditionType": "CASELOAD",
+      "conditionValue": "TST",
+      "blockAccess": false
+    }
+  ]
+}

--- a/wiremock-docker/mappings/get-splash-screen-condition-ALL.json
+++ b/wiremock-docker/mappings/get-splash-screen-condition-ALL.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/**ALL**"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-ALL-result.json"
+  }
+}

--- a/wiremock-docker/mappings/get-splash-screen-condition-BXI.json
+++ b/wiremock-docker/mappings/get-splash-screen-condition-BXI.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/BXI"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-BXI-result.json"
+  }
+}

--- a/wiremock-docker/mappings/get-splash-screen-condition-MDI.json
+++ b/wiremock-docker/mappings/get-splash-screen-condition-MDI.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/MDI"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-MDI-result.json"
+  }
+}

--- a/wiremock-docker/mappings/splash-screen-condition-create.json
+++ b/wiremock-docker/mappings/splash-screen-condition-create.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-screen-result.json"
+  }
+}

--- a/wiremock-docker/mappings/splash-screen-condition-update.json
+++ b/wiremock-docker/mappings/splash-screen-condition-update.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPattern": "^/api/splash-screen/OIDCHOLO/condition/CASELOAD/[A-Z]{3}/[\\w-]+$"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-screen-result.json"
+  }
+}

--- a/wiremock/__files/splash-condition-ALL-result.json
+++ b/wiremock/__files/splash-condition-ALL-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "**ALL**",
+  "blockAccess": false
+}

--- a/wiremock/__files/splash-condition-BXI-result.json
+++ b/wiremock/__files/splash-condition-BXI-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "BXI",
+  "blockAccess": true
+}

--- a/wiremock/__files/splash-condition-MDI-result.json
+++ b/wiremock/__files/splash-condition-MDI-result.json
@@ -1,0 +1,5 @@
+{
+  "conditionType": "CASELOAD",
+  "conditionValue": "MDI",
+  "blockAccess": true
+}

--- a/wiremock/__files/splash-screen-result.json
+++ b/wiremock/__files/splash-screen-result.json
@@ -1,0 +1,13 @@
+{
+  "moduleName": "OIDCHOLO",
+  "warningText": "Access to this screen will soon be revoked",
+  "blockedText": "You can not longer use this screen, use DPS",
+  "blockAccessType": "NO",
+  "conditions": [
+    {
+      "conditionType": "CASELOAD",
+      "conditionValue": "TST",
+      "blockAccess": false
+    }
+  ]
+}

--- a/wiremock/mappings/get-splash-screen-condition-ALL.json
+++ b/wiremock/mappings/get-splash-screen-condition-ALL.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/**ALL**"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-ALL-result.json"
+  }
+}

--- a/wiremock/mappings/get-splash-screen-condition-BXI.json
+++ b/wiremock/mappings/get-splash-screen-condition-BXI.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/BXI"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-BXI-result.json"
+  }
+}

--- a/wiremock/mappings/get-splash-screen-condition-MDI.json
+++ b/wiremock/mappings/get-splash-screen-condition-MDI.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition/CASELOAD/MDI"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-condition-MDI-result.json"
+  }
+}

--- a/wiremock/mappings/splash-screen-condition-create.json
+++ b/wiremock/mappings/splash-screen-condition-create.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/api/splash-screen/OIDCHOLO/condition"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-screen-result.json"
+  }
+}

--- a/wiremock/mappings/splash-screen-condition-update.json
+++ b/wiremock/mappings/splash-screen-condition-update.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "PUT",
+    "urlPattern": "^/api/splash-screen/OIDCHOLO/condition/CASELOAD/[A-Z]{3}/[\\w-]+$"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "splash-screen-result.json"
+  }
+}


### PR DESCRIPTION
Introduced splash screen status handling for prisons, including APIs for getting, updating, adding, and removing conditions. Updated server middleware, services, and routes to support the feature. Added corresponding mock files and tests to ensure robustness.