### PR TITLE
MAP-2608 Update Docker image source and upgrade dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - AUTHORIZATION_SERVER_TOKEN_ENDPOINT_URL=http://hmpps-auth:8080/auth/oauth/token
 
   locations-inside-prison-api:
-    image: quay.io/hmpps/hmpps-locations-inside-prison-api:latest
+    image: ghcr.io/ministryofjustice/hmpps-locations-inside-prison-api:latest
     container_name: locations-inside-prison-api
     depends_on:
       - hmpps-auth


### PR DESCRIPTION
### Summary

This pull request includes the following changes:
- Updated the Docker image source for `locations-inside-prison-api` in the `docker-compose.yml` file, switching from `quay.io` to `ghcr.io` to align with updated registry standards.


### Checklist

- [ ] Code changes are properly documented.
- [ ] Unit tests are written and passing.
- [ ] All dependencies are updated where necessary.

Please review the changes and provide feedback where applicable.