### PR TITLE
MAP-2775: handle location update errors if a location fails to update

### DIFF
--- a/server/data/types/locationsApi/bulkCapacityChanges.d.ts
+++ b/server/data/types/locationsApi/bulkCapacityChanges.d.ts
@@ -23,7 +23,7 @@ export type BulkCapacityUpdateChanges = {
 type Change = {
   key: string
   message: string
-  type: string
-  previousValue: number
-  newValue: number
+  type?: string
+  previousValue?: number
+  newValue?: number
 }


### PR DESCRIPTION
If a location is not found in the bulk update it fails. It is currently split to update a wing at a time

Handle this and carry on processing the rest of the data. Inform the user of errors at the top of the list

<img width="3456" height="3018" alt="screencapture-localhost-3000-admin-LTI-2025-09-11-15_35_07" src="https://github.com/user-attachments/assets/5f307cce-9bb0-4144-a478-1dfd14aac7ff" />
