### PR TITLE
MAP-3024: Change cancel link text on cert change disclaimer page

### DIFF
--- a/server/commonTransactions/certChangeDisclaimer/index.ts
+++ b/server/commonTransactions/certChangeDisclaimer/index.ts
@@ -25,6 +25,8 @@ class ExtendedTransaction extends CommonTransaction {
         override locals(req: FormWizard.Request, res: Response): TypedLocals {
           const locals = super.locals(req, res)
 
+          locals.cancelText = 'Cancel'
+
           if (title) {
             locals.title = res.locals.title.replace('This', title(req, res))
           }


### PR DESCRIPTION
## Summary
- Changes the cancel link text on the 'Cert change required' screen from "Cancel and return to location details" to "Cancel", since the cancel link on this page doesn't always return to a specific location's details page.

## Test plan
- [ ] Navigate to a cert change disclaimer page (e.g. via change cell capacity with cert active) and verify the cancel link text reads "Cancel"
- [ ] Verify the cancel link still navigates to the correct destination