### PR TITLE
MAP-3026: Fix approval page content for signed op cap changes

### DIFF
--- a/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
@@ -158,10 +158,7 @@ context('Cell Certificate - Change Requests - Review', () => {
           cy.get('[data-qa="title-caption"]').should('contain', 'Test (HMP)')
           cy.get('h1').should('contain', 'You are about to approve a change to the cell certificate')
           cy.get('.govuk-fieldset__legend--m').should('contain', 'Confirm change agreed with capacity management')
-          cy.get('.govuk-hint').should(
-            'contain',
-            'I confirm that this change has been agreed with capacity management.',
-          )
+          cy.get('.govuk-hint').should('contain', 'I confirm this change has been agreed with capacity management')
           cy.get('label[for="confirmation"]').should('contain', 'I understand and agree with the above statement.')
           approvePage.confirmButton().should('contain', 'Update cell certificate')
           approvePage.cancelLink().should('be.visible')

--- a/server/controllers/cellCertificate/changeRequests/review/approve.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/approve.ts
@@ -37,10 +37,6 @@ export default class Approve extends FormInitialStep {
 
     if (approvalRequest.approvalType === 'SIGNED_OP_CAP') {
       const confirmationField = req.form.options.fields.confirmation
-      confirmationField.fieldset.legend.text = 'Confirm change agreed with capacity management'
-      confirmationField.hint = {
-        text: 'I confirm that this change has been agreed with capacity management.',
-      }
       confirmationField.errorMessages = {
         required: 'Confirm that the change has been agreed with capacity management',
       }

--- a/server/views/pages/cellCertificate/changeRequests/review/approve.njk
+++ b/server/views/pages/cellCertificate/changeRequests/review/approve.njk
@@ -1,11 +1,32 @@
 {% extends "../../../../partials/formStep.njk" %}
 
 {% block fields %}
-  {% if approvalRequest.approvalType !== 'SIGNED_OP_CAP' %}
+  {% if approvalRequest.approvalType === 'SIGNED_OP_CAP' %}
+    {{ govukCheckboxes({
+      name: 'confirmation',
+      id: 'confirmation',
+      fieldset: {
+        legend: {
+          text: 'Confirm change agreed with capacity management',
+          classes: 'govuk-fieldset__legend--m'
+        }
+      },
+      hint: {
+        text: 'I confirm this change has been agreed with capacity management'
+      },
+      errorMessage: fields.confirmation.errorMessage,
+      items: [
+        {
+          text: 'I understand and agree with the above statement.',
+          value: 'yes',
+          checked: fields.confirmation.value === 'yes'
+        }
+      ]
+    }) }}
+  {% else %}
     <p>
       You must confirm that all cells on the certificate meet the required standards to update the certificate.
     </p>
+    {{ super() }}
   {% endif %}
-
-  {{ super() }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Renders the SIGNED_OP_CAP checkbox directly in the approve template instead of relying on runtime field mutation in the controller, which was not reliably taking effect
- Updates hint text from "I confirm that this change has been agreed with capacity management." to "I confirm this change has been agreed with capacity management"
- Retains the `errorMessages` override in the controller for error summary handling

## Test plan
- [ ] Verify signed op cap approval page shows correct content: prison name caption, "Confirm change agreed with capacity management" heading, "I confirm this change has been agreed with capacity management" body text
- [ ] Verify non-SIGNED_OP_CAP approval pages still show certification standards text
- [ ] Verify error message displays correctly when checkbox is not checked