### PR TITLE
MAP-2820: Fix smart quotes in change request show template

### DIFF
--- a/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
@@ -311,4 +311,40 @@ context('Cell Certificate - Change Requests - Show', () => {
       })
     })
   })
+
+  context('Review copy and withdraw button by status', () => {
+    context('As a certificate administrator (MANAGE_RES_LOCATIONS_OP_CAP)', () => {
+      beforeEach(() => {
+        setupStubs(['MANAGE_RES_LOCATIONS_OP_CAP'])
+        cy.signIn()
+      })
+
+      it('Shows the review copy and withdraw button when status is PENDING', () => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({ status: 'PENDING' }),
+        )
+
+        CellCertificateChangeRequestsShowPage.goTo('id1')
+        Page.verifyOnPage(CellCertificateChangeRequestsShowPage)
+
+        cy.contains('This request is being reviewed').should('be.visible')
+        cy.contains('You are unable to make changes to this location').should('be.visible')
+        cy.contains('.govuk-button', 'Withdraw request').should('be.visible')
+      })
+      ;(['APPROVED', 'REJECTED', 'WITHDRAWN'] as const).forEach(status => {
+        it(`Hides the review copy and withdraw button when status is ${status}`, () => {
+          LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+            CertificationApprovalRequestFactory.build({ status }),
+          )
+
+          CellCertificateChangeRequestsShowPage.goTo('id1')
+          Page.verifyOnPage(CellCertificateChangeRequestsShowPage)
+
+          cy.contains('This request is being reviewed').should('not.exist')
+          cy.contains('You are unable to make changes to this location').should('not.exist')
+          cy.contains('.govuk-button', 'Withdraw request').should('not.exist')
+        })
+      })
+    })
+  })
 })

--- a/server/views/pages/cellCertificate/changeRequests/show.njk
+++ b/server/views/pages/cellCertificate/changeRequests/show.njk
@@ -7,7 +7,7 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {% if approvalRequest.status == ‘PENDING’ %}
+        {% if approvalRequest.status == 'PENDING' %}
           <p>
             This request is being reviewed by the establishment’s authorising director. If approved, the cell certificate
             will be updated with this change.
@@ -19,7 +19,7 @@
           </p>
         {% endif %}
 
-        {{ certificationApprovalRequestSummary(approvalRequest, userMap, locationMap, constants, canAccess(‘certificate_change_request_withdraw’), true) }}
+        {{ certificationApprovalRequestSummary(approvalRequest, userMap, locationMap, constants, canAccess('certificate_change_request_withdraw'), true) }}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- PR #544 introduced curly quotes around `'PENDING'` and `'certificate_change_request_withdraw'` in `server/views/pages/cellCertificate/changeRequests/show.njk`. Nunjucks treated them as undefined identifiers, so the review copy and withdraw button were hidden for all statuses — including PENDING — which was reported as a regression in JIRA.
- Replaced the curly quotes with ASCII single quotes so the conditional and the `canAccess` call evaluate as intended.
- Added Cypress coverage to `show.cy.ts` for all four status branches (PENDING shows review copy + withdraw button for a certificate administrator; APPROVED/REJECTED/WITHDRAWN hide both).

## Test plan
- [x] `npm run typecheck`
- [x] `npx cypress run --spec integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts` — all 10 cases pass
- [ ] Manual QA in Dev: PENDING request shows "This request is being reviewed…" copy and the Withdraw button for a cert admin; APPROVED / REJECTED / WITHDRAWN requests hide both