### PR TITLE
MAP-2984: Show cell capacity change request details

### DIFF
--- a/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
@@ -357,7 +357,7 @@ context('Cell Certificate - Change Requests - Review', () => {
       })
 
       it('Correctly displays the change request info and approve/reject options', () => {
-        cy.get('h1').should('contain', 'Review cell capacity request')
+        cy.get('h1').should('contain', 'Cell capacity request details')
 
         testGovukSummaryList('overview-list-CAPACITY_CHANGE', [
           ['Location', 'A-1-001'],

--- a/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
@@ -329,6 +329,56 @@ context('Cell Certificate - Change Requests - Review', () => {
       })
     })
 
+    context('When the approvalType is CAPACITY_CHANGE', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'CAPACITY_CHANGE',
+            locationId: '7e570000-0000-1000-8000-000000000001',
+            locationKey: 'TST-A-1-001',
+            reasonForChange: 'Needed to change it',
+            locations: [
+              CertificateLocationFactory.build({
+                id: '7e570000-0000-1000-8000-000000000001',
+                pathHierarchy: 'A-1-001',
+                certifiedNormalAccommodation: 2,
+                currentCertifiedNormalAccommodation: 1,
+                workingCapacity: 2,
+                currentWorkingCapacity: 1,
+                maxCapacity: 3,
+                currentMaxCapacity: 2,
+              }),
+            ],
+          }),
+        )
+
+        CellCertificateChangeRequestsReviewPage.goTo('id1')
+        reviewPage = Page.verifyOnPage(CellCertificateChangeRequestsReviewPage)
+      })
+
+      it('Correctly displays the change request info and approve/reject options', () => {
+        cy.get('h1').should('contain', 'Review cell capacity request')
+
+        testGovukSummaryList('overview-list-CAPACITY_CHANGE', [
+          ['Location', 'A-1-001'],
+          ['Change type', 'Cell capacity'],
+          ['Explanation', 'Needed to change it'],
+          ['Submitted on', '3 October 2024'],
+          ['Submitted by', 'john smith'],
+        ])
+
+        testGovukTable('capacity-change-table', [['A-1-001', '1 → 2', '1 → 2', '2 → 3']])
+
+        cy.get('input[name="approveOrReject"][type="radio"][value="APPROVE"]').should('exist')
+        cy.get('input[name="approveOrReject"][type="radio"][value="REJECT"]').should('exist')
+      })
+
+      it('Displays an error when no option is checked', () => {
+        reviewPage.submit({})
+        Page.checkForError('approveOrReject', 'Select if you want to approve or reject this change')
+      })
+    })
+
     context('When the approvalType is REACTIVATION', () => {
       beforeEach(() => {
         LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(

--- a/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
@@ -357,7 +357,7 @@ context('Cell Certificate - Change Requests - Review', () => {
       })
 
       it('Correctly displays the change request info and approve/reject options', () => {
-        cy.get('h1').should('contain', 'Cell capacity request details')
+        cy.get('h1').should('contain', 'Review cell capacity request')
 
         testGovukSummaryList('overview-list-CAPACITY_CHANGE', [
           ['Location', 'A-1-001'],

--- a/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
@@ -221,6 +221,53 @@ context('Cell Certificate - Change Requests - Show', () => {
       })
     })
 
+    context('When the approvalType is CAPACITY_CHANGE', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'CAPACITY_CHANGE',
+            locationId: '7e570000-0000-1000-8000-000000000001',
+            locationKey: 'TST-A-1-001',
+            reasonForChange: 'Needed to change it',
+            certifiedNormalAccommodationChange: 1,
+            workingCapacityChange: 1,
+            maxCapacityChange: 1,
+            locations: [
+              CertificateLocationFactory.build({
+                id: '7e570000-0000-1000-8000-000000000001',
+                pathHierarchy: 'A-1-001',
+                certifiedNormalAccommodation: 2,
+                currentCertifiedNormalAccommodation: 1,
+                workingCapacity: 2,
+                currentWorkingCapacity: 1,
+                maxCapacity: 3,
+                currentMaxCapacity: 2,
+              }),
+            ],
+          }),
+        )
+
+        CellCertificateChangeRequestsShowPage.goTo('id1')
+        Page.verifyOnPage(CellCertificateChangeRequestsShowPage)
+      })
+
+      it('Correctly displays the change request info', () => {
+        cy.get('[data-qa="title-caption"]').should('contain', 'Cell A-1-001')
+        cy.get('h1').should('contain', 'Cell capacity request details')
+
+        testGovukSummaryList('overview-list-CAPACITY_CHANGE', [
+          ['Location', 'A-1-001'],
+          ['Change type', 'Cell capacity'],
+          ['Explanation', 'Needed to change it'],
+          ['Submitted on', '3 October 2024'],
+          ['Submitted by', 'john smith'],
+          ['Status', 'Awaiting approval'],
+        ])
+
+        testGovukTable('capacity-change-table', [['A-1-001', '1 → 2', '1 → 2', '2 → 3']])
+      })
+    })
+
     context('When the approvalType is REACTIVATION', () => {
       beforeEach(() => {
         LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(

--- a/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
@@ -30,7 +30,7 @@ context('Cell Certificate - Change Requests - Show', () => {
           ['Change type', 'Add new locations to certificate'],
           ['Submitted on', '3 October 2024'],
           ['Submitted by', 'john smith'],
-          ['Status', 'Awaiting approval'],
+          ['Status', 'Awaiting review'],
         ])
 
         testGovukTable('wing-table', [
@@ -78,7 +78,7 @@ context('Cell Certificate - Change Requests - Show', () => {
           ['Explanation', 'Needed to change it'],
           ['Submitted on', '3 October 2024'],
           ['Submitted by', 'john smith'],
-          ['Status', 'Awaiting approval'],
+          ['Status', 'Awaiting review'],
         ])
 
         testGovukTable('cap-change-table', [['TST', '5 → 9']])
@@ -261,7 +261,7 @@ context('Cell Certificate - Change Requests - Show', () => {
           ['Explanation', 'Needed to change it'],
           ['Submitted on', '3 October 2024'],
           ['Submitted by', 'john smith'],
-          ['Status', 'Awaiting approval'],
+          ['Status', 'Awaiting review'],
         ])
 
         testGovukTable('capacity-change-table', [['A-1-001', '1 → 2', '1 → 2', '2 → 3']])

--- a/integration_tests/e2e/cellCertificate/changeRequests/withdraw.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/withdraw.cy.ts
@@ -70,6 +70,36 @@ context('Cell Certificate - Change Requests - Withdraw', () => {
       })
     })
 
+    context('When the approvalType is CAPACITY_CHANGE', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'CAPACITY_CHANGE',
+          }),
+        )
+        LocationsApiStubber.stub.stubLocationsCertificationLocationWithdraw()
+
+        CellCertificateChangeRequestsWithdrawPage.goTo('id1')
+        withdrawPage = Page.verifyOnPage(CellCertificateChangeRequestsWithdrawPage)
+      })
+
+      it('Displays an error when no explanation is entered', () => {
+        withdrawPage.submit({})
+        Page.checkForError('explanation', 'Explain why you are withdrawing this request')
+      })
+
+      it('Redirects to change requests and displays a banner', () => {
+        withdrawPage.submit({ explanation: 'Not good enough' })
+
+        Page.verifyOnPage(CellCertificateChangeRequestsIndexPage)
+        cy.get('#govuk-notification-banner-title').contains('Success')
+        cy.get('.govuk-notification-banner__content h3').contains('Change request withdrawn')
+        cy.get('.govuk-notification-banner__content p').contains(
+          'You have withdrawn the change request for cell A-1-001.',
+        )
+      })
+    })
+
     context('When the approvalType is CELL_SANITATION', () => {
       beforeEach(() => {
         LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(

--- a/server/controllers/cellCertificate/changeRequests/review/index.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/index.ts
@@ -27,7 +27,11 @@ export default class Review extends FormInitialStep {
       res.locals.titleCaption = prisonResidentialSummary.prisonSummary.prisonName
     }
 
-    res.locals.title = `Review ${approvalTypeDescription(approvalRequest.approvalType, constants, location).toLowerCase()} request`
+    if (approvalRequest.approvalType === 'CAPACITY_CHANGE') {
+      res.locals.title = `${approvalTypeDescription(approvalRequest.approvalType, constants, location)} request details`
+    } else {
+      res.locals.title = `Review ${approvalTypeDescription(approvalRequest.approvalType, constants, location).toLowerCase()} request`
+    }
 
     await addUsersToUserMap([approvalRequest.requestedBy])(req, res, null)
 

--- a/server/controllers/cellCertificate/changeRequests/review/index.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/index.ts
@@ -27,11 +27,7 @@ export default class Review extends FormInitialStep {
       res.locals.titleCaption = prisonResidentialSummary.prisonSummary.prisonName
     }
 
-    if (approvalRequest.approvalType === 'CAPACITY_CHANGE') {
-      res.locals.title = `${approvalTypeDescription(approvalRequest.approvalType, constants, location)} request details`
-    } else {
-      res.locals.title = `Review ${approvalTypeDescription(approvalRequest.approvalType, constants, location).toLowerCase()} request`
-    }
+    res.locals.title = `Review ${approvalTypeDescription(approvalRequest.approvalType, constants, location).toLowerCase()} request`
 
     await addUsersToUserMap([approvalRequest.requestedBy])(req, res, null)
 

--- a/server/formatters/approvalTypeDescription.test.ts
+++ b/server/formatters/approvalTypeDescription.test.ts
@@ -34,6 +34,10 @@ describe('approvalTypeDescription', () => {
     expect(approvalTypeDescription('CELL_MARK', mockConstants, baseLocation)).toBe('Change cell door number')
   })
 
+  it('returns correct description for CAPACITY_CHANGE', () => {
+    expect(approvalTypeDescription('CAPACITY_CHANGE', mockConstants, baseLocation)).toBe('Cell capacity')
+  })
+
   it('returns approvalType for unknown type', () => {
     expect(approvalTypeDescription('UNKNOWN', mockConstants, baseLocation)).toBe('UNKNOWN')
   })

--- a/server/views/macros/certificationApprovalRequestSummary.njk
+++ b/server/views/macros/certificationApprovalRequestSummary.njk
@@ -12,7 +12,7 @@
   {% endif %}
 
   {% if request.status == 'PENDING' %}
-    {% set statusText = 'Awaiting approval' %}
+    {% set statusText = 'Awaiting review' %}
   {% elseif request.status == 'APPROVED' %}
     {% set statusText = 'Approved' %}
   {% elseif request.status == 'REJECTED' %}


### PR DESCRIPTION
## Summary
- Rename the PENDING status label from "Awaiting approval" to "Awaiting review" across all approval types in the shared change-request summary macro.
- Add e2e + unit test coverage for the CAPACITY_CHANGE approval type on the show, review and withdraw pages (the underlying rendering and "Cell capacity" change-type description landed on main via MAP-3151).

[MAP-2984](https://dsdmoj.atlassian.net/browse/MAP-2984)

[MAP-2984]: https://dsdmoj.atlassian.net/browse/MAP-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ