### PR TITLE
MAP-2955: Align cell capacity cert-change disclaimer H1

### DIFF
--- a/server/routes/changeCellCapacity/steps.ts
+++ b/server/routes/changeCellCapacity/steps.ts
@@ -48,7 +48,7 @@ const steps: FormWizard.Steps = {
   },
   ...CertChangeDisclaimer.getSteps({
     next: 'update-signed-op-cap',
-    title: (_req, _res) => `Changing cell capacity`,
+    title: (_req, _res) => `Changing the cell's capacity`,
   }),
   ...UpdateSignedOpCap.getSteps({ next: 'submit-certification-approval-request' }),
   ...SubmitCertificationApprovalRequest.getSteps({ next: '#' }),


### PR DESCRIPTION
## Summary
- Updates the H1 on the certificate change disclaimer shown when changing a cell's CNA or maximum capacity to match the MAP-2955 acceptance criteria: _"Changing the cell's capacity requires a change to the cell certificate"_.
- The disclaimer page, caption, body copy, Continue button and "Cancel and return to location details" link all already existed via the shared `CertChangeDisclaimer` common transaction; the only gap was the wording passed in from `changeCellCapacity/steps.ts`.

Based on `MAP-2984-cell-capacity-request-details` since that PR (#563) is still open and touches adjacent copy.

[MAP-2955](https://dsdmoj.atlassian.net/browse/MAP-2955)

[MAP-2955]: https://dsdmoj.atlassian.net/browse/MAP-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ