### PR TITLE
MAP-2982: Show cert mismatch warning on cell capacity confirm

### DIFF
--- a/integration_tests/e2e/changeCellCapacity/confirm.cy.ts
+++ b/integration_tests/e2e/changeCellCapacity/confirm.cy.ts
@@ -188,5 +188,62 @@ context('Change cell capacity - confirm', () => {
       cy.get('.govuk-notification-banner__content h3').contains('Capacity updated')
       cy.get('.govuk-notification-banner__content p').contains('You have updated the capacity of 1-1-001.')
     })
+
+    it('does not show the cert mismatch warning when cert is inactive', () => {
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
+      const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
+      changeCellCapacityPage.workingCapacityInput().clear().type('2')
+      changeCellCapacityPage.continueButton().click()
+
+      Page.verifyOnPage(ConfirmCellCapacityPage)
+      cy.get('.govuk-inset-text').should('not.exist')
+    })
+  })
+
+  context('with the certificate active and only working capacity changed', () => {
+    const location = LocationFactory.build({
+      accommodationTypes: ['NORMAL_ACCOMMODATION'],
+      capacity: {
+        certifiedNormalAccommodation: 2,
+        maxCapacity: 3,
+        workingCapacity: 3,
+      },
+      leafLevel: true,
+      specialistCellTypes: [],
+      localName: '1-1-001',
+    })
+
+    beforeEach(() => {
+      cy.task('reset')
+      AuthStubber.stub.stubSignIn({ roles: ['MANAGE_RES_LOCATIONS_OP_CAP'] })
+      ManageUsersApiStubber.stub.stubManageUsers()
+      ManageUsersApiStubber.stub.stubManageUsersMe()
+      ManageUsersApiStubber.stub.stubManageUsersMeCaseloads()
+      LocationsApiStubber.stub.stubLocationsConstantsAccommodationType()
+      LocationsApiStubber.stub.stubLocationsConstantsConvertedCellType()
+      LocationsApiStubber.stub.stubLocationsConstantsDeactivatedReason()
+      LocationsApiStubber.stub.stubLocationsConstantsLocationType()
+      LocationsApiStubber.stub.stubLocationsConstantsSpecialistCellType()
+      LocationsApiStubber.stub.stubLocationsConstantsUsedForType()
+      LocationsApiStubber.stub.stubLocationsLocationsResidentialSummary()
+      LocationsApiStubber.stub.stubLocationsLocationsResidentialSummaryForLocation({ parentLocation: location })
+      LocationsApiStubber.stub.stubLocations(location)
+      LocationsApiStubber.stub.stubPrisonerLocationsId([])
+      LocationsApiStubber.stub.stubUpdateCapacity()
+      LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+      cy.signIn()
+    })
+
+    it('shows the cert mismatch inset text', () => {
+      ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
+      const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
+      changeCellCapacityPage.workingCapacityInput().clear().type('2')
+      changeCellCapacityPage.continueButton().click()
+
+      Page.verifyOnPage(ConfirmCellCapacityPage)
+      cy.get('.govuk-inset-text').contains(
+        "The cell's working capacity will not match the certified working capacity once you update the capacity.",
+      )
+    })
   })
 })

--- a/server/controllers/changeCellCapacity/confirm.test.ts
+++ b/server/controllers/changeCellCapacity/confirm.test.ts
@@ -90,6 +90,29 @@ You are increasing the cell’s maximum capacity by 1.
 This will increase the establishment’s maximum capacity from 30 to 31.`,
       })
     })
+
+    describe('when only working capacity has changed and the cert is active', () => {
+      beforeEach(() => {
+        sessionModel.onlyWorkingCapChanged = true
+      })
+
+      it('sets showCertMismatchWarning', () => {
+        const result = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
+        expect(result).toMatchObject({ showCertMismatchWarning: true })
+      })
+
+      it('does not set showCertMismatchWarning when the cert is inactive', () => {
+        deepRes.locals.prisonConfiguration.certificationApprovalRequired = 'INACTIVE'
+        const result = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
+        expect(result).not.toHaveProperty('showCertMismatchWarning')
+      })
+
+      it('does not set showCertMismatchWarning when the location is DRAFT', () => {
+        deepRes.locals.decoratedLocation.status = 'DRAFT'
+        const result = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
+        expect(result).not.toHaveProperty('showCertMismatchWarning')
+      })
+    })
   })
 
   describe('saveValues', () => {

--- a/server/controllers/changeCellCapacity/confirm.ts
+++ b/server/controllers/changeCellCapacity/confirm.ts
@@ -28,7 +28,7 @@ export default class ConfirmCellCapacity extends FormInitialStep {
   }
 
   override locals(req: FormWizard.Request, res: Response): TypedLocals {
-    const { decoratedLocation } = res.locals
+    const { decoratedLocation, prisonConfiguration } = res.locals
     const { maxCapacity, workingCapacity } = decoratedLocation.capacity
 
     const newWorkingCap = Number(req.sessionModel.get('workingCapacity'))
@@ -52,9 +52,15 @@ export default class ConfirmCellCapacity extends FormInitialStep {
 
     const changeSummary = changeSummaries.join('\n<br/><br/>\n')
 
+    const showCertMismatchWarning =
+      Boolean(req.sessionModel.get<boolean>('onlyWorkingCapChanged')) &&
+      prisonConfiguration?.certificationApprovalRequired === 'ACTIVE' &&
+      decoratedLocation.status !== 'DRAFT'
+
     return {
       changeSummary,
       buttonText: 'Update cell capacity',
+      ...(showCertMismatchWarning && { showCertMismatchWarning: true }),
     }
   }
 

--- a/server/views/pages/changeCellCapacity/confirm.njk
+++ b/server/views/pages/changeCellCapacity/confirm.njk
@@ -1,6 +1,7 @@
 {% extends "../../partials/formStep.njk" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% block fields %}
   {{ govukSummaryList({
@@ -33,4 +34,10 @@
 
     <p>{{ changeSummary | safe }}</p>
   </div>
+
+  {% if showCertMismatchWarning %}
+    {{ govukInsetText({
+      text: "The cell's working capacity will not match the certified working capacity once you update the capacity."
+    }) }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
Adds the inset warning to the cell capacity confirm page when the cert is active and only the working capacity has changed: _"The cell's working capacity will not match the certified working capacity once you update the capacity."_ Skipped for cert INACTIVE and DRAFT cells.

[MAP-2982](https://dsdmoj.atlassian.net/browse/MAP-2982)

[MAP-2982]: https://dsdmoj.atlassian.net/browse/MAP-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ