### PR TITLE
MAP-3116: Only notify users with relevant active caseload

### DIFF
--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -87,7 +87,7 @@ const stubManageUsersByCaseload = (page: string = '0') =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/manage-users-api/prisonusers/search\\?inclusiveRoles=true&status=ACTIVE&caseload=TST&accessRoles=[^&]+(,[^&]+)*&page=${page}&size=50`,
+      urlPattern: `/manage-users-api/prisonusers/search\\?inclusiveRoles=true&status=ACTIVE&activeCaseload=TST&accessRoles=[^&]+(,[^&]+)*&page=${page}&size=50`,
     },
     response: {
       status: 200,

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -87,7 +87,7 @@ describe('manageUsersApiClient', () => {
     testCall('get', '/users/USERNAME', true, () => apiClient.users.get, { username: 'USERNAME' })
     testCall(
       'getUsersByCaseload',
-      '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&caseload=CASELOAD&accessRoles=ROLE&size=50&page=1',
+      '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&activeCaseload=CASELOAD&accessRoles=ROLE&size=50&page=1',
       false,
       () => apiClient.users.getUsersByCaseload,
       { caseload: 'CASELOAD', accessRoles: 'ROLE', page: '1', size: '50' },

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -75,7 +75,7 @@ export default class ManageUsersApiClient extends BaseApiClient {
       PaginatedUsers,
       { caseload: string; accessRoles: string; page: string; size: string }
     >({
-      path: '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&caseload=:caseload&accessRoles=:accessRoles&page=:page&size=:size',
+      path: '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&activeCaseload=:caseload&accessRoles=:accessRoles&page=:page&size=:size',
       requestType: 'get',
     }),
   }


### PR DESCRIPTION
Only send certification approval notifications to users with relevant *active* caseload.

[MAP-3116](https://dsdmoj.atlassian.net/browse/MAP-3116)

[MAP-3116]: https://dsdmoj.atlassian.net/browse/MAP-3116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ