### PR TITLE
MAPB-381: Gate residential locations cards on user role

### DIFF
--- a/integration_tests/e2e/archivedLocations/index.cy.ts
+++ b/integration_tests/e2e/archivedLocations/index.cy.ts
@@ -27,7 +27,7 @@ context('Archived Locations Index', () => {
   context('With location in caseload', () => {
     beforeEach(() => {
       cy.task('reset')
-      cy.task('stubSignIn')
+      cy.task('stubSignIn', { roles: ['VIEW_INTERNAL_LOCATION'] })
       cy.task('stubManageUsers')
       cy.task('stubManageUsersMe')
       cy.task('stubManageUsersMeCaseloads')

--- a/integration_tests/e2e/inactiveCells/index.cy.ts
+++ b/integration_tests/e2e/inactiveCells/index.cy.ts
@@ -47,7 +47,7 @@ context('Inactive Cells Index', () => {
   context('With location in caseload', () => {
     beforeEach(() => {
       cy.task('reset')
-      cy.task('stubSignIn')
+      cy.task('stubSignIn', { roles: ['VIEW_INTERNAL_LOCATION'] })
       cy.task('stubManageUsers')
       cy.task('stubManageUsersMe')
       cy.task('stubManageUsersMeCaseloads')

--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -27,7 +27,7 @@ context('Index', () => {
   context('With the default role but certification inactive', () => {
     beforeEach(() => {
       cy.task('reset')
-      AuthStubber.stub.stubSignIn()
+      AuthStubber.stub.stubSignIn({ roles: ['VIEW_INTERNAL_LOCATION'] })
       LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
       ManageUsersApiStubber.stub.stubManageUsersMe()
       ManageUsersApiStubber.stub.stubManageUsersMeCaseloads()

--- a/integration_tests/e2e/viewLocations/index.cy.ts
+++ b/integration_tests/e2e/viewLocations/index.cy.ts
@@ -49,7 +49,7 @@ context('View Locations Index', () => {
   context('With the default role', () => {
     beforeEach(() => {
       cy.task('reset')
-      cy.task('stubSignIn')
+      cy.task('stubSignIn', { roles: ['VIEW_INTERNAL_LOCATION'] })
       cy.task('stubManageUsers')
       cy.task('stubManageUsersMe')
       cy.task('stubManageUsersMeCaseloads')

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -12,7 +12,10 @@ interface UserToken {
 
 const createToken = (userToken: UserToken) => {
   // authorities in the session are always prefixed by ROLE.
-  const authorities = (userToken.roles || []).map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`)) || []
+  // Defaults to VIEW_INTERNAL_LOCATION so most tests, which assume the user has
+  // baseline residential read access, do not need to opt in explicitly.
+  const roles = userToken.roles ?? ['VIEW_INTERNAL_LOCATION']
+  const authorities = roles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
   const payload = {
     name: userToken.name || 'john smith',
     user_name: 'USER1',

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -12,10 +12,7 @@ interface UserToken {
 
 const createToken = (userToken: UserToken) => {
   // authorities in the session are always prefixed by ROLE.
-  // Defaults to VIEW_INTERNAL_LOCATION so most tests, which assume the user has
-  // baseline residential read access, do not need to opt in explicitly.
-  const roles = userToken.roles ?? ['VIEW_INTERNAL_LOCATION']
-  const authorities = roles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
+  const authorities = (userToken.roles || []).map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`)) || []
   const payload = {
     name: userToken.name || 'john smith',
     user_name: 'USER1',

--- a/server/middleware/populateCards.ts
+++ b/server/middleware/populateCards.ts
@@ -109,7 +109,6 @@ export default function populateCards(locationsService: LocationsService) {
     // Non-residential locations cards and permission message
     if (req.featureFlags.nonResi && nonResiActive) {
       // Check for non-resi specific roles (these are used by the non-resi app)
-      const userRoles = res.locals.user.userRoles || []
       const hasEditRole = userRoles.includes('NONRESI__MAINTAIN_LOCATION')
 
       res.locals.nonResiCards = [

--- a/server/middleware/populateCards.ts
+++ b/server/middleware/populateCards.ts
@@ -3,16 +3,28 @@ import setCanAccess from './setCanAccess'
 import LocationsService from '../services/locationsService'
 import config from '../config'
 
+const RESI_ROLES = [
+  'VIEW_INTERNAL_LOCATION',
+  'MANAGE_RESIDENTIAL_LOCATIONS',
+  'MANAGE_RES_LOCATIONS_OP_CAP',
+  'MANAGE_RES_LOCATIONS_ADMIN',
+  'RESI__CERT_VIEWER',
+  'RESI__CERT_REVIEWER',
+]
+
 export default function populateCards(locationsService: LocationsService) {
   return asyncMiddleware((req, res, next) => {
     setCanAccess(locationsService)
     const certificationEnabled = res.locals.prisonConfiguration?.certificationApprovalRequired === 'ACTIVE'
     const resiActive = res.locals.prisonConfiguration?.resiLocationServiceActive === 'ACTIVE'
     const nonResiActive = res.locals.prisonConfiguration?.nonResiServiceActive === 'ACTIVE'
+    const userRoles = res.locals.user.userRoles || []
+    const hasResiRole = userRoles.some(role => RESI_ROLES.includes(role))
+    const showResiCards = resiActive && hasResiRole
 
     // Residential locations cards and permission message
     let manageLocationsCard = null
-    if (resiActive) {
+    if (showResiCards) {
       if (certificationEnabled) {
         manageLocationsCard = {
           clickable: true,
@@ -38,7 +50,7 @@ export default function populateCards(locationsService: LocationsService) {
       manageLocationsCard,
       {
         clickable: true,
-        visible: resiActive,
+        visible: showResiCards,
         heading: 'View all inactive cells',
         href: '/inactive-cells',
         description: 'View details of all inactive cells in the establishment and reactivate them.',
@@ -46,7 +58,7 @@ export default function populateCards(locationsService: LocationsService) {
       },
       {
         clickable: true,
-        visible: resiActive,
+        visible: showResiCards,
         heading: 'Archived locations',
         href: '/archived-locations',
         description: 'View locations that have been permanently deactivated as residential locations.',
@@ -54,7 +66,7 @@ export default function populateCards(locationsService: LocationsService) {
       },
       {
         clickable: true,
-        visible: resiActive && certificationEnabled,
+        visible: showResiCards && certificationEnabled,
         heading: 'Cell certificate',
         href: '/cell-certificate/current',
         description: 'View the current certificate and requested changes.',
@@ -86,7 +98,13 @@ export default function populateCards(locationsService: LocationsService) {
       },
     ]
 
-    res.locals.resiPermissionMessage = resiActive ? null : 'You do not have permission to view Residential locations.'
+    if (!resiActive) {
+      res.locals.resiPermissionMessage = 'You do not have permission to view Residential locations.'
+    } else if (!hasResiRole) {
+      res.locals.resiPermissionMessage = 'You do not have permission to manage Residential locations.'
+    } else {
+      res.locals.resiPermissionMessage = null
+    }
 
     // Non-residential locations cards and permission message
     if (req.featureFlags.nonResi && nonResiActive) {

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -62,7 +62,40 @@ describe('GET /', () => {
     })
   })
 
-  it('should render index page with "Manage residential locations" when certificationApprovalRequired is ACTIVE', async () => {
+  it('should render index page with "Manage residential locations" when user has a residential role and certificationApprovalRequired is ACTIVE', async () => {
+    locationsService.getPrisonConfiguration.mockResolvedValue({
+      prisonId: 'TST',
+      resiLocationServiceActive: 'ACTIVE',
+      nonResiServiceActive: 'INACTIVE',
+      includeSegregationInRollCount: 'INACTIVE',
+      certificationApprovalRequired: 'ACTIVE',
+    })
+
+    app = appWithAllRoutes({
+      services: {
+        auditService,
+        locationsService,
+      },
+      userSupplier: () => ({ ...user, userRoles: ['MANAGE_RESIDENTIAL_LOCATIONS'] }),
+    })
+
+    auditService.logPageView.mockResolvedValue(null)
+    const res = await request(app).get('/')
+
+    expect(res.text).toContain('govuk-breadcrumbs')
+    expect(res.text).toContain('Residential locations')
+    expect(res.text).toContain('Manage residential locations')
+    expect(res.text).toContain('View all inactive cells')
+    expect(res.text).toContain('Archived locations')
+    expect(res.text).toContain('Cell certificate')
+
+    expect(auditService.logPageView).toHaveBeenCalledWith(Page.INDEX, {
+      who: user.username,
+      correlationId: expect.any(String),
+    })
+  })
+
+  it('should render permission message when resi service is active but user has no residential role', async () => {
     locationsService.getPrisonConfiguration.mockResolvedValue({
       prisonId: 'TST',
       resiLocationServiceActive: 'ACTIVE',
@@ -82,16 +115,12 @@ describe('GET /', () => {
     auditService.logPageView.mockResolvedValue(null)
     const res = await request(app).get('/')
 
-    expect(res.text).toContain('govuk-breadcrumbs')
     expect(res.text).toContain('Residential locations')
-    expect(res.text).toContain('Manage residential locations')
-    expect(res.text).toContain('View all inactive cells')
-    expect(res.text).toContain('Archived locations')
-    expect(res.text).toContain('Cell certificate')
+    expect(res.text).toContain('You do not have permission to manage Residential locations.')
 
-    expect(auditService.logPageView).toHaveBeenCalledWith(Page.INDEX, {
-      who: user.username,
-      correlationId: expect.any(String),
-    })
+    expect(res.text).not.toContain('Manage residential locations')
+    expect(res.text).not.toContain('View all inactive cells')
+    expect(res.text).not.toContain('Archived locations')
+    expect(res.text).not.toContain('Cell certificate')
   })
 })


### PR DESCRIPTION
[MAPB-381](https://dsdmoj.atlassian.net/browse/MAPB-381)

Companion PR to [hmpps-non-residential-locations-ui#165](https://github.com/ministryofjustice/hmpps-non-residential-locations-ui/pull/165).

## Problem

The residential cards in `populateCards.ts` were rendered whenever the prison's `resiLocationServiceActive` configuration was `'ACTIVE'`, with no role check on the user. From the QA matrix:

| Resi active | Non-resi active | Has resi role | Has non-resi role | Symptom |
|---|---|---|---|---|
| Active | Active | No | Yes | Resi tiles displayed despite the user having no residential role |
| Active | Active | No | No | Resi tiles displayed despite the user having no residential role |

Expected: when the resi service is active but the user lacks a residential role, the Residential section should display "You do not have permission to manage Residential locations." instead of clickable cards.

## Fix

Adds a role check in `server/middleware/populateCards.ts`. The Manage / Inactive cells / Archived / Cell certificate cards are now hidden unless the user holds at least one of:

- `VIEW_INTERNAL_LOCATION`
- `MANAGE_RESIDENTIAL_LOCATIONS`
- `MANAGE_RES_LOCATIONS_OP_CAP`
- `MANAGE_RES_LOCATIONS_ADMIN`
- `RESI__CERT_VIEWER`
- `RESI__CERT_REVIEWER`

This list mirrors the role set already used to gate the DPS homepage Locations tile in `hmpps-micro-frontend-components/server/services/utils/getServicesForUser.ts:478-484`, so the landing page and the homepage tile now agree on who counts as a "residential user".

The `resiPermissionMessage` becomes a three-state value:

- service inactive → `"You do not have permission to view Residential locations."` (existing behaviour, unchanged)
- service active, user has no resi role → `"You do not have permission to manage Residential locations."` (new)
- service active, user has a resi role → `null`

The `cardBlock.njk` macro already renders `permissionMessage` when no cards are visible, so the new branch needs no view changes.

## Why each scenario is fixed

**Row 2** (Active resi, Active non-resi, no resi role, has non-resi role): user has only `NONRESI__MAINTAIN_LOCATION` which is not in `RESI_ROLES`, so `hasResiRole` is false. All four resi cards are hidden, `resiPermissionMessage` becomes the "manage" string, and the section renders the message under the heading.

**Row 3** (Active resi, Active non-resi, no resi role, no non-resi role): same as Row 2 — `hasResiRole` is false and the message is rendered. The non-resi side is unchanged and still shows the "View non-residential locations" tile (because `nonResiActive` is true), which is what Row 3's expected behaviour calls for.

## Out of scope

The Admin card is gated on `req.canAccess('administer_residential')` rather than the role list. That's deliberate — admin access requires a specific permission and is independent of whether the user has read access to residential locations. Left untouched.

The two `[DEV] ...` cards are also independent (gated on `developerMode`) and unchanged.

[MAPB-381]: https://dsdmoj.atlassian.net/browse/MAPB-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ