### PR TITLE
MAPB-212: Add admin toggle for OIMILOCA and OIMULOCA NOMIS screens

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -160,6 +160,12 @@ interface AllLocals {
   prisonNonHousingDisabled: boolean
   nestedBaseUrl: string
   nomisScreenBlocked: boolean
+  nomisLocationScreenBlocked: boolean
+  nomisUsageScreenBlocked: boolean
+  moduleName: string
+  currentScreenStatus: string
+  screenLabel: string
+  currentStatusDescription: string
   prisonId: string
   prisonerLocation: PrisonerLocation
   prisonResidentialSummary: PrisonResidentialSummary

--- a/server/controllers/admin/nomisScreen/confirm.test.ts
+++ b/server/controllers/admin/nomisScreen/confirm.test.ts
@@ -1,0 +1,211 @@
+import { NextFunction, Response } from 'express'
+import FormWizard from 'hmpo-form-wizard'
+import { DeepPartial } from 'fishery'
+import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
+import PrisonService from '../../../services/prisonService'
+import AnalyticsService from '../../../services/analyticsService'
+import NomisScreenStatusChangeConfirm from './confirm'
+
+describe('adminNomisScreenSwitch', () => {
+  const controller = new NomisScreenStatusChangeConfirm({ route: '/' })
+  let deepReq: DeepPartial<FormWizard.Request>
+  let deepRes: DeepPartial<Response>
+  let next: NextFunction
+  const prisonService = new PrisonService(null) as jest.Mocked<PrisonService>
+  const analyticsService = new AnalyticsService(null) as jest.Mocked<AnalyticsService>
+
+  beforeEach(() => {
+    deepReq = {
+      flash: jest.fn(),
+      params: { moduleName: 'OIMILOCA' },
+      session: {
+        referrerUrl: '',
+        systemToken: 'token',
+      },
+      form: {
+        values: {
+          screenStatus: '',
+        },
+      },
+      services: {
+        analyticsService,
+        prisonService,
+      },
+      sessionModel: {
+        set: jest.fn(),
+        get: jest.fn() as FormWizard.Request['sessionModel']['get'],
+      },
+    }
+    deepRes = {
+      locals: {
+        errorlist: [],
+        prisonConfiguration: {
+          prisonId: 'MDI',
+          resiLocationServiceActive: 'ACTIVE',
+          nonResiServiceActive: 'ACTIVE',
+          includeSegregationInRollCount: 'INACTIVE',
+          certificationApprovalRequired: 'INACTIVE',
+        },
+        options: {},
+        prisonId: 'MDI',
+        moduleName: 'OIMILOCA',
+        currentScreenStatus: 'ACCESSIBLE',
+      },
+      redirect: jest.fn(),
+    }
+    next = jest.fn()
+
+    prisonService.addCondition = jest.fn()
+    prisonService.removeCondition = jest.fn()
+    prisonService.updateScreen = jest.fn()
+    prisonService.getScreenStatus = jest.fn()
+    analyticsService.sendEvent = jest.fn()
+  })
+
+  describe('saveValues', () => {
+    it('addCondition with blockAccess=false when moving from ACCESSIBLE to WARNING', async () => {
+      deepReq.form.values.screenStatus = 'WARNING'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.addCondition).toHaveBeenCalledWith('token', 'MDI', false, 'OIMILOCA')
+      expect(prisonService.updateScreen).not.toHaveBeenCalled()
+      expect(prisonService.removeCondition).not.toHaveBeenCalled()
+    })
+
+    it('addCondition with blockAccess=true when moving from ACCESSIBLE to BLOCKED', async () => {
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.addCondition).toHaveBeenCalledWith('token', 'MDI', true, 'OIMILOCA')
+    })
+
+    it('updateScreen with block=true when moving from WARNING to BLOCKED', async () => {
+      deepRes.locals.currentScreenStatus = 'WARNING'
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.updateScreen).toHaveBeenCalledWith('token', 'MDI', true, 'OIMILOCA')
+      expect(prisonService.addCondition).not.toHaveBeenCalled()
+    })
+
+    it('updateScreen with block=false when moving from BLOCKED to WARNING', async () => {
+      deepRes.locals.currentScreenStatus = 'BLOCKED'
+      deepReq.form.values.screenStatus = 'WARNING'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.updateScreen).toHaveBeenCalledWith('token', 'MDI', false, 'OIMILOCA')
+    })
+
+    it('removeCondition when moving from BLOCKED to ACCESSIBLE', async () => {
+      deepRes.locals.currentScreenStatus = 'BLOCKED'
+      deepReq.form.values.screenStatus = 'ACCESSIBLE'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.removeCondition).toHaveBeenCalledWith('token', 'MDI', 'OIMILOCA')
+      expect(prisonService.updateScreen).not.toHaveBeenCalled()
+    })
+
+    it('no-op when moving from ACCESSIBLE to ACCESSIBLE', async () => {
+      deepReq.form.values.screenStatus = 'ACCESSIBLE'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.removeCondition).not.toHaveBeenCalled()
+      expect(prisonService.updateScreen).not.toHaveBeenCalled()
+      expect(prisonService.addCondition).not.toHaveBeenCalled()
+    })
+
+    it('passes moduleName through to API calls for OIMULOCA', async () => {
+      deepRes.locals.moduleName = 'OIMULOCA'
+      deepRes.locals.currentScreenStatus = 'ACCESSIBLE'
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(prisonService.addCondition).toHaveBeenCalledWith('token', 'MDI', true, 'OIMULOCA')
+    })
+
+    it('sends an analytics event', async () => {
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(analyticsService.sendEvent).toHaveBeenCalledWith(deepReq, 'nomis_screen_status', {
+        prison_id: 'MDI',
+        module_name: 'OIMILOCA',
+        status: 'BLOCKED',
+      })
+    })
+
+    it('calls next on success', async () => {
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('forwards errors to next', async () => {
+      const boom = new Error('boom') as SanitisedError<object>
+      ;(prisonService.addCondition as jest.Mock).mockImplementation(() => {
+        throw boom
+      })
+      deepReq.form.values.screenStatus = 'BLOCKED'
+      await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(next).toHaveBeenCalledWith(boom)
+    })
+  })
+
+  describe('loadCurrentStatus', () => {
+    it('returns ACCESSIBLE when getScreenStatus throws 404', async () => {
+      const notFound = new Error('Not Found') as SanitisedError<object>
+      notFound.responseStatus = 404
+      ;(prisonService.getScreenStatus as jest.Mock).mockImplementation(() => Promise.reject(notFound))
+
+      await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(deepRes.locals.currentScreenStatus).toBe('ACCESSIBLE')
+      expect(deepRes.locals.moduleName).toBe('OIMILOCA')
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('returns BLOCKED when condition exists with blockAccess=true', async () => {
+      ;(prisonService.getScreenStatus as jest.Mock).mockResolvedValue({
+        conditionType: 'CASELOAD',
+        conditionValue: 'MDI',
+        blockAccess: true,
+      })
+
+      await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(deepRes.locals.currentScreenStatus).toBe('BLOCKED')
+    })
+
+    it('returns WARNING when condition exists with blockAccess=false', async () => {
+      ;(prisonService.getScreenStatus as jest.Mock).mockResolvedValue({
+        conditionType: 'CASELOAD',
+        conditionValue: 'MDI',
+        blockAccess: false,
+      })
+
+      await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(deepRes.locals.currentScreenStatus).toBe('WARNING')
+    })
+
+    it('forwards non-404 errors to next', async () => {
+      const boom = new Error('boom') as SanitisedError<object>
+      boom.responseStatus = 500
+      ;(prisonService.getScreenStatus as jest.Mock).mockImplementation(() => Promise.reject(boom))
+
+      await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(next).toHaveBeenCalledWith(boom)
+    })
+
+    it('forwards an error for unsupported moduleName', async () => {
+      deepReq.params.moduleName = 'OIMMHOLO'
+
+      await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error))
+    })
+  })
+})

--- a/server/controllers/admin/nomisScreen/confirm.ts
+++ b/server/controllers/admin/nomisScreen/confirm.ts
@@ -1,0 +1,150 @@
+import FormWizard from 'hmpo-form-wizard'
+import { NextFunction, Response } from 'express'
+import { TypedLocals } from '../../../@types/express'
+import backUrl from '../../../utils/backUrl'
+import FormInitialStep from '../../base/formInitialStep'
+import { ModuleName } from '../../../data/types/locationsApi/moduleName'
+import PrisonService from '../../../services/prisonService'
+
+type ScreenStatus = 'ACCESSIBLE' | 'WARNING' | 'BLOCKED'
+type NomisModuleName = Exclude<ModuleName, 'OIMMHOLO'>
+
+const SCREEN_LABELS: Record<NomisModuleName, string> = {
+  OIMILOCA: 'Maintain internal locations (OIMILOCA)',
+  OIMULOCA: 'Maintain internal usage (OIMULOCA)',
+}
+
+const STATUS_DESCRIPTIONS: Record<ScreenStatus, string> = {
+  ACCESSIBLE: 'Accessible',
+  WARNING: 'Warning shown',
+  BLOCKED: 'Blocked',
+}
+
+function parseModuleName(value: unknown): NomisModuleName {
+  if (value !== 'OIMILOCA' && value !== 'OIMULOCA') {
+    throw new Error(`Unsupported NOMIS screen module: ${value}`)
+  }
+  return value
+}
+
+async function fetchStatus(
+  prisonService: PrisonService,
+  token: string,
+  prisonId: string,
+  moduleName: NomisModuleName,
+): Promise<ScreenStatus> {
+  try {
+    const condition = await prisonService.getScreenStatus(token, prisonId, moduleName)
+    return condition.blockAccess ? 'BLOCKED' : 'WARNING'
+  } catch (error) {
+    if (error.responseStatus === 404) {
+      return 'ACCESSIBLE'
+    }
+    throw error
+  }
+}
+
+export default class NomisScreenStatusChangeConfirm extends FormInitialStep {
+  override middlewareSetup() {
+    this.use(this.loadCurrentStatus.bind(this))
+    super.middlewareSetup()
+  }
+
+  async loadCurrentStatus(req: FormWizard.Request, res: Response, next: NextFunction) {
+    try {
+      const moduleName = parseModuleName(req.params.moduleName)
+      const { prisonId } = res.locals.prisonConfiguration
+      res.locals.moduleName = moduleName
+      res.locals.currentScreenStatus = await fetchStatus(
+        req.services.prisonService,
+        req.session.systemToken,
+        prisonId,
+        moduleName,
+      )
+      next()
+    } catch (error) {
+      next(error)
+    }
+  }
+
+  override locals(req: FormWizard.Request, res: Response): TypedLocals {
+    const locals = super.locals(req, res)
+    const { prisonConfiguration, moduleName, currentScreenStatus } = res.locals
+    const { prisonId } = prisonConfiguration
+    const screenLabel = SCREEN_LABELS[moduleName as NomisModuleName]
+
+    const backLink = backUrl(req, {
+      fallbackUrl: `/admin/${prisonId}`,
+    })
+
+    const fields = { ...(locals.fields as FormWizard.Fields) }
+    const selected = (req.form.values.screenStatus as ScreenStatus) || (currentScreenStatus as ScreenStatus)
+    fields.screenStatus = {
+      ...fields.screenStatus,
+      items: fields.screenStatus.items.map(item => ({
+        ...item,
+        checked: item.value === selected,
+      })),
+    }
+
+    return {
+      ...locals,
+      fields,
+      backLink,
+      cancelLink: backLink,
+      title: `Update ${screenLabel} status`,
+      screenLabel,
+      currentStatusDescription: STATUS_DESCRIPTIONS[currentScreenStatus as ScreenStatus],
+      buttonText: 'Save',
+    }
+  }
+
+  override async saveValues(req: FormWizard.Request, res: Response, next: NextFunction) {
+    const { prisonId } = res.locals.prisonConfiguration
+    const { analyticsService, prisonService } = req.services
+    const moduleName = res.locals.moduleName as NomisModuleName
+    const currentStatus = res.locals.currentScreenStatus as ScreenStatus
+    const status = req.form.values.screenStatus as ScreenStatus
+
+    try {
+      const conditionExists = currentStatus !== 'ACCESSIBLE'
+
+      if (status === 'ACCESSIBLE') {
+        if (conditionExists) {
+          await prisonService.removeCondition(req.session.systemToken, prisonId, moduleName)
+        }
+      } else {
+        const block = status === 'BLOCKED'
+        if (conditionExists) {
+          await prisonService.updateScreen(req.session.systemToken, prisonId, block, moduleName)
+        } else {
+          await prisonService.addCondition(req.session.systemToken, prisonId, block, moduleName)
+        }
+      }
+
+      analyticsService.sendEvent(req, 'nomis_screen_status', {
+        prison_id: prisonId,
+        module_name: moduleName,
+        status,
+      })
+      return next()
+    } catch (error) {
+      return next(error)
+    }
+  }
+
+  override successHandler(req: FormWizard.Request, res: Response, _next: NextFunction) {
+    const { prisonId } = res.locals.prisonConfiguration
+    const moduleName = res.locals.moduleName as NomisModuleName
+
+    req.journeyModel.reset()
+    req.sessionModel.reset()
+
+    req.flash('success', {
+      title: `${SCREEN_LABELS[moduleName]} status`,
+      content: `You have changed the ${SCREEN_LABELS[moduleName]} status.`,
+    })
+
+    res.redirect(`/admin/${prisonId}`)
+  }
+}

--- a/server/data/types/locationsApi/moduleName.d.ts
+++ b/server/data/types/locationsApi/moduleName.d.ts
@@ -1,1 +1,1 @@
-export declare type ModuleName = 'OIMMHOLO'
+export declare type ModuleName = 'OIMMHOLO' | 'OIMILOCA' | 'OIMULOCA'

--- a/server/middleware/getServicePrisonsNonHousingDisplay.ts
+++ b/server/middleware/getServicePrisonsNonHousingDisplay.ts
@@ -2,6 +2,7 @@ import { type NextFunction, Request, type Response } from 'express'
 import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import logger from '../../logger'
 import PrisonService from '../services/prisonService'
+import { ModuleName } from '../data/types/locationsApi/moduleName'
 
 export default function getServicePrisonsNonHousingDisplay() {
   return async (req: Request, res: Response, next: NextFunction) => {
@@ -31,7 +32,14 @@ export function getSplashScreenStatus() {
     const { prisonId } = res.locals
 
     try {
-      res.locals.nomisScreenBlocked = await getScreenBlockStatus(req.services.prisonService, systemToken, prisonId)
+      const [housing, location, usage] = await Promise.all([
+        getScreenBlockStatus(req.services.prisonService, systemToken, prisonId, 'OIMMHOLO'),
+        getScreenBlockStatus(req.services.prisonService, systemToken, prisonId, 'OIMILOCA'),
+        getScreenBlockStatus(req.services.prisonService, systemToken, prisonId, 'OIMULOCA'),
+      ])
+      res.locals.nomisScreenBlocked = housing
+      res.locals.nomisLocationScreenBlocked = location
+      res.locals.nomisUsageScreenBlocked = usage
       next()
     } catch (error) {
       handleScreenStatusError(error, prisonId, next)
@@ -39,21 +47,30 @@ export function getSplashScreenStatus() {
   }
 }
 
-async function getScreenBlockStatus(prisonService: PrisonService, token: string, prisonId: string): Promise<boolean> {
+async function getScreenBlockStatus(
+  prisonService: PrisonService,
+  token: string,
+  prisonId: string,
+  moduleName: ModuleName,
+): Promise<boolean> {
   try {
-    const condition = await prisonService.getScreenStatus(token, prisonId)
+    const condition = await prisonService.getScreenStatus(token, prisonId, moduleName)
     return condition.blockAccess
   } catch (error) {
     if (error.responseStatus === 404) {
-      return getFallbackScreenStatus(prisonService, token)
+      return getFallbackScreenStatus(prisonService, token, moduleName)
     }
     throw error
   }
 }
 
-async function getFallbackScreenStatus(prisonService: PrisonService, token: string): Promise<boolean> {
+async function getFallbackScreenStatus(
+  prisonService: PrisonService,
+  token: string,
+  moduleName: ModuleName,
+): Promise<boolean> {
   try {
-    const condition = await prisonService.getScreenStatus(token, '**ALL**')
+    const condition = await prisonService.getScreenStatus(token, '**ALL**', moduleName)
     return condition.blockAccess
   } catch (error) {
     if (error.responseStatus === 404) {

--- a/server/routes/admin/nomisScreen/fields.ts
+++ b/server/routes/admin/nomisScreen/fields.ts
@@ -1,0 +1,31 @@
+const fields = {
+  screenStatus: {
+    component: 'govukRadios',
+    validate: ['required'],
+    errorMessages: { required: 'Select a status for the NOMIS screen' },
+    id: 'screenStatus',
+    name: 'screenStatus',
+    fieldset: {
+      legend: {
+        text: 'NOMIS screen status',
+        classes: 'govuk-fieldset__legend--m',
+      },
+    },
+    items: [
+      {
+        value: 'ACCESSIBLE',
+        text: 'Accessible — no splash screen message',
+      },
+      {
+        value: 'WARNING',
+        text: 'Show splash screen warning the screen will be switched off',
+      },
+      {
+        value: 'BLOCKED',
+        text: 'Switch screen off and show splash screen message',
+      },
+    ],
+  },
+}
+
+export default fields

--- a/server/routes/admin/nomisScreen/index.ts
+++ b/server/routes/admin/nomisScreen/index.ts
@@ -1,0 +1,20 @@
+import express from 'express'
+import wizard from 'hmpo-form-wizard'
+import steps from './steps'
+import fields from './fields'
+import protectRoute from '../../../middleware/protectRoute'
+import populatePrisonConfiguration from '../../../middleware/populatePrisonConfiguration'
+
+const router = express.Router({ mergeParams: true })
+
+router.use(
+  populatePrisonConfiguration(),
+  protectRoute('administer_residential'),
+  wizard(steps, fields, {
+    name: 'change-nomis-screen-status',
+    templatePath: 'pages/admin/nomisScreen',
+    csrf: false,
+  }),
+)
+
+export default router

--- a/server/routes/admin/nomisScreen/steps.ts
+++ b/server/routes/admin/nomisScreen/steps.ts
@@ -1,0 +1,18 @@
+import FormWizard from 'hmpo-form-wizard'
+import NomisScreenStatusChangeConfirm from '../../../controllers/admin/nomisScreen/confirm'
+
+const steps: FormWizard.Steps = {
+  '/': {
+    entryPoint: true,
+    reset: true,
+    resetJourney: true,
+    skip: true,
+    next: 'confirm',
+  },
+  '/confirm': {
+    fields: ['screenStatus'],
+    controller: NomisScreenStatusChangeConfirm,
+  },
+}
+
+export default steps

--- a/server/routes/adminRouter.test.ts
+++ b/server/routes/adminRouter.test.ts
@@ -141,30 +141,28 @@ describe('GET /admin/PRISON_ID', () => {
     })
     prisonService.getServiceStatus.mockResolvedValue('')
 
-    // First call to getScreenStatus fails with 404
-    const error: SanitisedError<object> = new Error('Not Found')
-    error.responseStatus = 404
-    prisonService.getScreenStatus.mockImplementationOnce(() => Promise.reject(error))
-
-    // Second call to getScreenStatus (with **ALL**) succeeds
-    prisonService.getScreenStatus.mockImplementationOnce(() =>
-      Promise.resolve({
-        conditionType: 'CASELOAD',
-        conditionValue: '**ALL**',
-        blockAccess: true,
-      }),
-    )
+    const notFound: SanitisedError<object> = new Error('Not Found')
+    notFound.responseStatus = 404
+    // Primary lookup (per-prison) returns 404 for every module, fallback (**ALL**) succeeds with blockAccess=true
+    prisonService.getScreenStatus.mockImplementation(async (_token, prisonId) => {
+      if (prisonId === '**ALL**') {
+        return { conditionType: 'CASELOAD', conditionValue: '**ALL**', blockAccess: true }
+      }
+      throw notFound
+    })
 
     return request(app)
       .get('/admin/TST')
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        // Check that getScreenStatus was called twice
-        // First with 'TST', then with '**ALL**'
-        expect(prisonService.getScreenStatus).toHaveBeenCalledTimes(2)
-        expect(prisonService.getScreenStatus.mock.calls[0][1]).toBe('TST')
-        expect(prisonService.getScreenStatus.mock.calls[1][1]).toBe('**ALL**')
+        // 3 modules × (primary + fallback) = 6 calls
+        expect(prisonService.getScreenStatus).toHaveBeenCalledTimes(6)
+        const callsByPrison = prisonService.getScreenStatus.mock.calls.map(args => args[1])
+        expect(callsByPrison.filter(p => p === 'TST')).toHaveLength(3)
+        expect(callsByPrison.filter(p => p === '**ALL**')).toHaveLength(3)
+        const modulesCalled = prisonService.getScreenStatus.mock.calls.map(args => args[2])
+        expect(modulesCalled).toEqual(expect.arrayContaining(['OIMMHOLO', 'OIMILOCA', 'OIMULOCA']))
 
         // Check that the page was rendered with blockAccess=true from the fallback
         expect(res.text).toContain('govuk-breadcrumbs')
@@ -184,26 +182,21 @@ describe('GET /admin/PRISON_ID', () => {
     })
     prisonService.getServiceStatus.mockResolvedValue('')
 
-    // Create a 404 error
-    const error: SanitisedError<object> = new Error('Not Found')
-    error.responseStatus = 404
-
-    // First call to getScreenStatus fails with 404
-    prisonService.getScreenStatus.mockImplementationOnce(() => Promise.reject(error))
-
-    // Second call to getScreenStatus (with **ALL**) also fails with 404
-    prisonService.getScreenStatus.mockImplementationOnce(() => Promise.reject(error))
+    const notFound: SanitisedError<object> = new Error('Not Found')
+    notFound.responseStatus = 404
+    // Both per-prison and fallback return 404 for every module
+    prisonService.getScreenStatus.mockImplementation(() => Promise.reject(notFound))
 
     return request(app)
       .get('/admin/TST')
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        // Check that getScreenStatus was called twice
-        // First with 'TST', then with '**ALL**'
-        expect(prisonService.getScreenStatus).toHaveBeenCalledTimes(2)
-        expect(prisonService.getScreenStatus.mock.calls[0][1]).toBe('TST')
-        expect(prisonService.getScreenStatus.mock.calls[1][1]).toBe('**ALL**')
+        // 3 modules × (primary + fallback) = 6 calls
+        expect(prisonService.getScreenStatus).toHaveBeenCalledTimes(6)
+        const callsByPrison = prisonService.getScreenStatus.mock.calls.map(args => args[1])
+        expect(callsByPrison.filter(p => p === 'TST')).toHaveLength(3)
+        expect(callsByPrison.filter(p => p === '**ALL**')).toHaveLength(3)
 
         // Check that the page was rendered (blockAccess should default to false)
         expect(res.text).toContain('govuk-breadcrumbs')

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -40,6 +40,7 @@ import changeResiStatusRouter from './admin/resi'
 import changeNonResiStatusRouter from './admin/nonResi'
 import changeCertApprovalStatusRouter from './admin/certApproval'
 import changeIncludeSegInRollCountStatusRouter from './admin/segInRollCount'
+import changeNomisScreenStatusRouter from './admin/nomisScreen'
 import ingestRouter from './admin/ingest'
 import cellCertificateRouter from './cellCertificate'
 import populatePrisonConfiguration from '../middleware/populatePrisonConfiguration'
@@ -114,6 +115,7 @@ export default function routes(services: Services): Router {
   router.use('/admin/:prisonId/change-non-resi-status', changeNonResiStatusRouter)
   router.use('/admin/:prisonId/change-include-seg-in-roll-count', changeIncludeSegInRollCountStatusRouter)
   router.use('/admin/:prisonId/change-certification-status', changeCertApprovalStatusRouter)
+  router.use('/admin/:prisonId/change-nomis-screen-status/:moduleName', changeNomisScreenStatusRouter)
   router.use('/admin/:prisonId/ingest-cert', ingestRouter)
 
   if (config.developerMode) {

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,5 +1,6 @@
 import { PrisonApiClient } from '../data/prisonApiClient'
 import { ServiceCode } from '../data/types/locationsApi/serviceCode'
+import { ModuleName } from '../data/types/locationsApi/moduleName'
 
 export default class PrisonService {
   constructor(private readonly prisonApiClient: PrisonApiClient) {}
@@ -16,16 +17,16 @@ export default class PrisonService {
     return this.prisonApiClient.servicePrisons.deactivatePrisonService(token, { prisonId, serviceCode })
   }
 
-  async getScreenStatus(token: string, prisonId: string) {
-    return this.prisonApiClient.splashScreen.getScreenStatus(token, { prisonId, moduleName: 'OIMMHOLO' })
+  async getScreenStatus(token: string, prisonId: string, moduleName: ModuleName = 'OIMMHOLO') {
+    return this.prisonApiClient.splashScreen.getScreenStatus(token, { prisonId, moduleName })
   }
 
-  async addCondition(token: string, prisonId: string, block: boolean = true) {
+  async addCondition(token: string, prisonId: string, block: boolean = true, moduleName: ModuleName = 'OIMMHOLO') {
     return this.prisonApiClient.splashScreen.addCondition(
       token,
       {
         prisonId,
-        moduleName: 'OIMMHOLO',
+        moduleName,
       },
       {
         conditionType: 'CASELOAD',
@@ -35,14 +36,14 @@ export default class PrisonService {
     )
   }
 
-  async removeCondition(token: string, prisonId: string) {
-    return this.prisonApiClient.splashScreen.removeCondition(token, { prisonId, moduleName: 'OIMMHOLO' })
+  async removeCondition(token: string, prisonId: string, moduleName: ModuleName = 'OIMMHOLO') {
+    return this.prisonApiClient.splashScreen.removeCondition(token, { prisonId, moduleName })
   }
 
-  async updateScreen(token: string, prisonId: string, block: boolean) {
+  async updateScreen(token: string, prisonId: string, block: boolean, moduleName: ModuleName = 'OIMMHOLO') {
     return this.prisonApiClient.splashScreen.updateScreen(token, {
       prisonId,
-      moduleName: 'OIMMHOLO',
+      moduleName,
       blockScreen: block === true ? 'true' : 'false',
     })
   }

--- a/server/views/pages/admin/index.njk
+++ b/server/views/pages/admin/index.njk
@@ -29,6 +29,22 @@
   {% endif %}
 {% endset %}
 
+{% set locationScreenBlocked %}
+  {% if nomisLocationScreenBlocked %}
+    Blocked
+  {% else %}
+    Not-Blocked
+  {% endif %}
+{% endset %}
+
+{% set usageScreenBlocked %}
+  {% if nomisUsageScreenBlocked %}
+    Blocked
+  {% else %}
+    Not-Blocked
+  {% endif %}
+{% endset %}
+
 {% set resiHtml %}
   <span class="hmpps-inactive-location-banner">
         {{ govukSummaryList({rows:[
@@ -122,6 +138,40 @@
         },
           value: {
             text: screenBlocked
+          }
+        },
+        {
+          key: {
+            text: 'OIMILOCA screen blocked'
+          },
+          value: {
+            text: locationScreenBlocked
+          },
+          actions: {
+            items: [
+              {
+                href: '/admin/' + prisonConfiguration.prisonId + '/change-nomis-screen-status/OIMILOCA',
+                text: "Change",
+                visuallyHiddenText: "OIMILOCA NOMIS screen",
+                classes: "govuk-link--no-visited-state"}
+            ]
+          }
+        },
+        {
+          key: {
+            text: 'OIMULOCA screen blocked'
+          },
+          value: {
+            text: usageScreenBlocked
+          },
+          actions: {
+            items: [
+              {
+                href: '/admin/' + prisonConfiguration.prisonId + '/change-nomis-screen-status/OIMULOCA',
+                text: "Change",
+                visuallyHiddenText: "OIMULOCA NOMIS screen",
+                classes: "govuk-link--no-visited-state"}
+            ]
           }
         },
         {

--- a/server/views/pages/admin/nomisScreen/confirm.njk
+++ b/server/views/pages/admin/nomisScreen/confirm.njk
@@ -1,0 +1,34 @@
+{% extends "../../../partials/formStep.njk" %}
+
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set nomisScreenHtml %}
+  <span class="hmpps-inactive-location-banner">
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: { text: 'Prison' },
+            value: { text: prisonConfiguration.prisonId }
+          },
+          {
+            key: { text: 'Screen' },
+            value: { text: screenLabel }
+          },
+          {
+            key: { text: 'Current status' },
+            value: { text: currentStatusDescription }
+          }
+        ],
+        classes: 'hmpps-inactive-location-banner-summary-list' }) }}
+  </span>
+{% endset %}
+
+{% block fields %}
+  {{ govukNotificationBanner({
+    html: nomisScreenHtml,
+    classes: 'govuk-notification-banner__headerless'
+  }) }}
+
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds a form wizard at `/admin/:prisonId/change-nomis-screen-status/:moduleName` so prison admins can manage the splash-screen state of OIMILOCA (Maintain internal locations) and OIMULOCA (Maintain internal usage) independently from non-resi activation
- Each NOMIS screen now has three states surfaced in the admin UI: **Accessible** (no splash), **Warning shown** (splash informs users the screen will be switched off), **Blocked** (screen switched off with informational splash). Moving between states maps onto `addCondition` / `updateScreen` / `removeCondition` on the prison-api splash-screen endpoints
- Admin index page now displays the current state of OIMILOCA and OIMULOCA with a Change link per row, mirroring the existing OIMMHOLO row pattern

Ticket: https://dsdmoj.atlassian.net/browse/MAPB-212

## Test plan
- [ ] Visit `/admin/<prisonId>` as a user with `MANAGE_RES_LOCATIONS_ADMIN` — confirm two new rows for OIMILOCA / OIMULOCA show current state and a Change link
- [ ] Click Change on OIMILOCA — confirm the wizard preselects the current state and saving with "Accessible" calls `removeCondition`
- [ ] From Accessible → Warning, confirm `addCondition(block=false)` is called and the splash is configured but the screen remains accessible in NOMIS
- [ ] From Warning → Blocked (and vice versa), confirm `updateScreen` is called with the appropriate `blockScreen` value
- [ ] Repeat for OIMULOCA — confirm the moduleName flows through to all API calls
- [ ] Confirm the existing resi/non-resi/OIMMHOLO behaviour is unchanged (backward-compatible signature change to `prisonService.getScreenStatus/addCondition/removeCondition/updateScreen` — defaults to `OIMMHOLO`)
- [ ] `npm test`, `npm run typecheck`, `npm run lint` pass (the pre-existing `cypress.config.ts` module-resolution error is unrelated)