### PR TITLE
MAPB-212: Fix NOMIS screen wizard error and clarify admin row labels

### DIFF
--- a/integration_tests/e2e/admin/index.cy.ts
+++ b/integration_tests/e2e/admin/index.cy.ts
@@ -6,6 +6,7 @@ import ResiStatusConfirmPage from '../../pages/admin/resi/confirm'
 import NonResiStatusConfirmPage from '../../pages/admin/nonResi/confirm'
 import CertApprovalConfirmPage from '../../pages/admin/certApproval/confirm'
 import SegInRollCountConfirmPage from '../../pages/admin/segInRollCount/confirm'
+import NomisScreenStatusConfirmPage from '../../pages/admin/nomisScreen/confirm'
 
 context('Admin Index', () => {
   context('Without the MANAGE_RES_LOCATIONS_ADMIN role', () => {
@@ -162,6 +163,41 @@ context('Admin Index', () => {
       cy.get('#govuk-notification-banner-title').contains('Success')
       cy.get('.govuk-notification-banner__content h3').contains('Residential location status')
       cy.get('.govuk-notification-banner__content p').contains('You have changed the residential location status.')
+    })
+  })
+
+  context('With the MANAGE_RES_LOCATIONS_ADMIN role - NOMIS screen toggle', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn', { roles: ['MANAGE_RES_LOCATIONS_ADMIN'] })
+      cy.task('stubManageUsers')
+      cy.task('stubManageUsersMe')
+      cy.task('stubManageUsersMeCaseloads')
+      cy.task('stubPrisonConfiguration')
+      cy.task('stubGetSplashScreenCondition')
+      cy.task('stubCreateSplashScreenCondition', { moduleName: 'OIMILOCA' })
+      cy.signIn()
+    })
+
+    it('Change link opens the OIMILOCA wizard and saves a new status', () => {
+      PrisonConfigurationIndexPage.goTo('TST')
+      const prisonConfigurationIndexPage = Page.verifyOnPage(PrisonConfigurationIndexPage)
+      prisonConfigurationIndexPage.checkOnPage()
+
+      cy.get('a[href$="/change-nomis-screen-status/OIMILOCA"]').click()
+
+      const nomisScreenPage = Page.verifyOnPage(NomisScreenStatusConfirmPage)
+      nomisScreenPage.checkOnPage()
+
+      nomisScreenPage.radio('BLOCKED').check()
+      nomisScreenPage.saveButton().click()
+
+      Page.verifyOnPage(PrisonConfigurationIndexPage)
+      cy.get('#govuk-notification-banner-title').contains('Success')
+      cy.get('.govuk-notification-banner__content h3').contains('Maintain internal locations (OIMILOCA) status')
+      cy.get('.govuk-notification-banner__content p').contains(
+        'You have changed the Maintain internal locations (OIMILOCA) status.',
+      )
     })
   })
 })

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -74,14 +74,15 @@ const stubDisplayHousingCheckboxesPost = (returnData: { prisonid: 'TST'; prison:
     jsonBody: returnData,
   })
 
-const stubGetSplashScreenCondition = (
-  prisonId: string = 'TST',
-  returnData: SplashCondition = { conditionType: 'CASELOAD', conditionValue: 'TST', blockAccess: false },
-) =>
+const stubGetSplashScreenCondition = ({
+  prisonId = 'TST',
+  moduleName = 'OIMMHOLO',
+  returnData = { conditionType: 'CASELOAD', conditionValue: 'TST', blockAccess: false },
+}: { prisonId?: string; moduleName?: string; returnData?: SplashCondition } = {}) =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: `/prison-api/api/splash-screen/OIMMHOLO/condition/CASELOAD/${prisonId}`,
+      urlPath: `/prison-api/api/splash-screen/${moduleName}/condition/CASELOAD/${prisonId}`,
     },
     response: {
       status: 200,
@@ -99,11 +100,14 @@ const sampleSplashResult = {
   blockedText: 'BLOCKED',
   blockAccessType: 'COND',
 }
-const stubCreateSplashScreenCondition = (returnData: SplashScreen = sampleSplashResult) =>
+const stubCreateSplashScreenCondition = ({
+  moduleName = 'OIMMHOLO',
+  returnData = sampleSplashResult,
+}: { moduleName?: string; returnData?: SplashScreen } = {}) =>
   stubFor({
     request: {
       method: 'POST',
-      urlPath: '/prison-api/api/splash-screen/OIMMHOLO/condition',
+      urlPath: `/prison-api/api/splash-screen/${moduleName}/condition`,
     },
     response: {
       status: 200,
@@ -114,15 +118,16 @@ const stubCreateSplashScreenCondition = (returnData: SplashScreen = sampleSplash
     },
   })
 
-const stubUpdateSplashScreenCondition = (
-  prisonId: string = 'TST',
-  blockScreen: boolean = false,
-  returnData: SplashScreen = sampleSplashResult,
-) =>
+const stubUpdateSplashScreenCondition = ({
+  prisonId = 'TST',
+  moduleName = 'OIMMHOLO',
+  blockScreen = false,
+  returnData = sampleSplashResult,
+}: { prisonId?: string; moduleName?: string; blockScreen?: boolean; returnData?: SplashScreen } = {}) =>
   stubFor({
     request: {
       method: 'PUT',
-      urlPattern: `/prison-api/api/splash-screen/OIMMHOLO/condition/CASELOAD/${prisonId}/${blockScreen}`,
+      urlPattern: `/prison-api/api/splash-screen/${moduleName}/condition/CASELOAD/${prisonId}/${blockScreen}`,
     },
     response: {
       status: 200,

--- a/integration_tests/pages/admin/nomisScreen/confirm.ts
+++ b/integration_tests/pages/admin/nomisScreen/confirm.ts
@@ -1,0 +1,21 @@
+import Page, { PageElement } from '../../page'
+
+export default class NomisScreenStatusConfirmPage extends Page {
+  constructor() {
+    super('Update Maintain internal locations (OIMILOCA) status')
+  }
+
+  checkOnPage() {
+    super.checkOnPage()
+    cy.get('.govuk-summary-list__key').eq(1).contains('Screen')
+    cy.get('.govuk-summary-list__key').eq(2).contains('Current status')
+  }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
+
+  cancelLink = (): PageElement => cy.get('a:contains("Cancel and return to prison configuration details")')
+
+  radio = (value: string): PageElement => cy.get(`input[name="screenStatus"][value="${value}"]`)
+
+  saveButton = (): PageElement => cy.get('button:contains("Save")')
+}

--- a/server/controllers/admin/nomisScreen/confirm.test.ts
+++ b/server/controllers/admin/nomisScreen/confirm.test.ts
@@ -17,7 +17,6 @@ describe('adminNomisScreenSwitch', () => {
   beforeEach(() => {
     deepReq = {
       flash: jest.fn(),
-      params: { moduleName: 'OIMILOCA' },
       session: {
         referrerUrl: '',
         systemToken: 'token',
@@ -201,7 +200,7 @@ describe('adminNomisScreenSwitch', () => {
     })
 
     it('forwards an error for unsupported moduleName', async () => {
-      deepReq.params.moduleName = 'OIMMHOLO'
+      deepRes.locals.moduleName = 'OIMMHOLO'
 
       await controller.loadCurrentStatus(deepReq as FormWizard.Request, deepRes as Response, next)
 

--- a/server/controllers/admin/nomisScreen/confirm.ts
+++ b/server/controllers/admin/nomisScreen/confirm.ts
@@ -52,9 +52,8 @@ export default class NomisScreenStatusChangeConfirm extends FormInitialStep {
 
   async loadCurrentStatus(req: FormWizard.Request, res: Response, next: NextFunction) {
     try {
-      const moduleName = parseModuleName(req.params.moduleName)
+      const moduleName = parseModuleName(res.locals.moduleName)
       const { prisonId } = res.locals.prisonConfiguration
-      res.locals.moduleName = moduleName
       res.locals.currentScreenStatus = await fetchStatus(
         req.services.prisonService,
         req.session.systemToken,

--- a/server/routes/admin/nomisScreen/index.ts
+++ b/server/routes/admin/nomisScreen/index.ts
@@ -2,12 +2,14 @@ import express from 'express'
 import wizard from 'hmpo-form-wizard'
 import steps from './steps'
 import fields from './fields'
+import populateModuleName from './populateModuleName'
 import protectRoute from '../../../middleware/protectRoute'
 import populatePrisonConfiguration from '../../../middleware/populatePrisonConfiguration'
 
 const router = express.Router({ mergeParams: true })
 
 router.use(
+  populateModuleName,
   populatePrisonConfiguration(),
   protectRoute('administer_residential'),
   wizard(steps, fields, {

--- a/server/routes/admin/nomisScreen/populateModuleName.test.ts
+++ b/server/routes/admin/nomisScreen/populateModuleName.test.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from 'express'
+import populateModuleName from './populateModuleName'
+
+describe('populateModuleName', () => {
+  let req: Partial<Request>
+  let res: Partial<Response>
+  let next: NextFunction
+
+  beforeEach(() => {
+    req = { params: {} }
+    res = { locals: {} as Response['locals'] }
+    next = jest.fn()
+  })
+
+  it.each(['OIMILOCA', 'OIMULOCA'])('stashes %s on res.locals and calls next', moduleName => {
+    req.params.moduleName = moduleName
+
+    populateModuleName(req as Request, res as Response, next)
+
+    expect(res.locals.moduleName).toBe(moduleName)
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('forwards a 404 error for an unknown module', () => {
+    req.params.moduleName = 'OIMMHOLO'
+
+    populateModuleName(req as Request, res as Response, next)
+
+    expect(res.locals.moduleName).toBeUndefined()
+    const error = (next as jest.Mock).mock.calls[0][0]
+    expect(error).toBeInstanceOf(Error)
+    expect(error.status).toBe(404)
+  })
+
+  it('forwards a 404 error when moduleName is missing', () => {
+    populateModuleName(req as Request, res as Response, next)
+
+    expect(res.locals.moduleName).toBeUndefined()
+    const error = (next as jest.Mock).mock.calls[0][0]
+    expect(error).toBeInstanceOf(Error)
+    expect(error.status).toBe(404)
+  })
+})

--- a/server/routes/admin/nomisScreen/populateModuleName.ts
+++ b/server/routes/admin/nomisScreen/populateModuleName.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express'
+
+export const NOMIS_SCREEN_MODULES = ['OIMILOCA', 'OIMULOCA']
+
+// The :moduleName route param is captured by the parent mount. hmpo-form-wizard's
+// internal router does not merge it through to the step controllers, so it must be
+// read here (in a router with mergeParams) and stashed on res.locals.
+export default function populateModuleName(req: Request, res: Response, next: NextFunction) {
+  const moduleName = req.params.moduleName as string
+
+  if (!NOMIS_SCREEN_MODULES.includes(moduleName)) {
+    const error = new Error(`Unknown NOMIS screen module: ${moduleName}`) as Error & { status?: number }
+    error.status = 404
+    next(error)
+    return
+  }
+
+  res.locals.moduleName = moduleName
+  next()
+}

--- a/server/views/pages/admin/index.njk
+++ b/server/views/pages/admin/index.njk
@@ -142,7 +142,7 @@
         },
         {
           key: {
-            text: 'OIMILOCA screen blocked'
+            text: 'OIMILOCA (internal locations) screen blocked'
           },
           value: {
             text: locationScreenBlocked
@@ -159,7 +159,7 @@
         },
         {
           key: {
-            text: 'OIMULOCA screen blocked'
+            text: 'OIMULOCA (internal usage) screen blocked'
           },
           value: {
             text: usageScreenBlocked


### PR DESCRIPTION
## Summary
Follow-up fix to #612 (already merged). Two changes:

- **Bug fix:** clicking *Change* on the OIMILOCA/OIMULOCA rows took the user to an error screen. The `:moduleName` route param was read inside the form-wizard step controller, but `hmpo-form-wizard`'s internal router does not merge params from the parent mount, so it was `undefined` and the confirm step threw. A new `populateModuleName` middleware (running in a router that has `mergeParams`) now captures it and stashes it on `res.locals` before the wizard runs — the same pattern `prisonId` already uses.
- **Label clarity:** admin page rows now read `OIMILOCA (internal locations) screen blocked` and `OIMULOCA (internal usage) screen blocked`.

Also adds a Cypress integration test that clicks the Change link and drives the wizard end to end — the coverage gap that let this ship (unit tests injected `req.params` directly so never exercised the real form-wizard plumbing).