### PR TITLE
MAP-3195: Prevent reactivation that would require cert change unless permitted

### DIFF
--- a/integration_tests/e2e/reactivate/location/cell/init.cy.ts
+++ b/integration_tests/e2e/reactivate/location/cell/init.cy.ts
@@ -3,9 +3,10 @@ import ViewLocationsShowPage from '../../../../pages/viewLocations/show'
 import AuthSignInPage from '../../../../pages/authSignIn'
 import { setupStubs, location } from './setupStubs'
 import CheckCapacityPage from '../../../../pages/reactivate/location/checkCapacity'
+import NoCertChangeConfirmPage from '../../../../pages/reactivate/location/noCertChangeConfirm'
 
 context('Certification Reactivation - Cell - Init', () => {
-  context('without the MANAGE_RES_LOCATIONS_OP_CAP role', () => {
+  context('with a read-only role', () => {
     beforeEach(() => {
       setupStubs('RESI__CERT_VIEWER')
 
@@ -21,6 +22,36 @@ context('Certification Reactivation - Cell - Init', () => {
     it('redirects user to sign in page when visited directly', () => {
       cy.visit(`/reactivate/location/${location.id}`)
       Page.verifyOnPage(AuthSignInPage)
+    })
+  })
+
+  context('with the MANAGE_RESIDENTIAL_LOCATIONS role', () => {
+    context('for a temp inactive location', () => {
+      beforeEach(() => {
+        setupStubs('MANAGE_RESIDENTIAL_LOCATIONS', false)
+
+        cy.signIn()
+      })
+
+      it('displays the confirmation page', () => {
+        cy.visit(`/reactivate/location/${location.id}/`)
+
+        Page.verifyOnPage(NoCertChangeConfirmPage)
+      })
+    })
+
+    context('for an inactive location with reduced capacity on the certificate', () => {
+      beforeEach(() => {
+        setupStubs('MANAGE_RESIDENTIAL_LOCATIONS', true)
+
+        cy.signIn()
+      })
+
+      it('does not show the action in the menu on the show location page', () => {
+        ViewLocationsShowPage.goTo(location.prisonId, location.id)
+        const viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
+        viewLocationsShowPage.inactiveBannerActivateCellButton().should('not.exist')
+      })
     })
   })
 

--- a/integration_tests/e2e/reactivate/location/cell/setupStubs.ts
+++ b/integration_tests/e2e/reactivate/location/cell/setupStubs.ts
@@ -20,6 +20,7 @@ export const location = LocationFactory.build({
   localName: null,
   specialistCellTypes: ['ACCESSIBLE_CELL', 'CONSTANT_SUPERVISION'],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export function setupStubs(role: string, hasCertChange = true) {
@@ -29,6 +30,7 @@ export function setupStubs(role: string, hasCertChange = true) {
     stubLocation = LocationFactory.build({
       ...location,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
   }
 

--- a/integration_tests/e2e/reactivate/location/landing/setupStubs.ts
+++ b/integration_tests/e2e/reactivate/location/landing/setupStubs.ts
@@ -21,6 +21,7 @@ export const location = LocationFactory.build({
   specialistCellTypes: ['ACCESSIBLE_CELL', 'CONSTANT_SUPERVISION'],
   status: 'INACTIVE',
   locationType: 'LANDING',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell1 = LocationFactory.build({
@@ -45,6 +46,7 @@ export const cell1 = LocationFactory.build({
   localName: null,
   specialistCellTypes: ['ACCESSIBLE_CELL', 'CONSTANT_SUPERVISION'],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell2 = LocationFactory.build({
@@ -69,6 +71,7 @@ export const cell2 = LocationFactory.build({
   localName: null,
   specialistCellTypes: [],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell3 = LocationFactory.build({
@@ -93,6 +96,7 @@ export const cell3 = LocationFactory.build({
   localName: null,
   specialistCellTypes: [],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export function setupStubs(role: string, hasCertChange = true) {
@@ -105,18 +109,22 @@ export function setupStubs(role: string, hasCertChange = true) {
     stubLocation = LocationFactory.build({
       ...location,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 4 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell1 = LocationFactory.build({
       ...cell1,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell2 = LocationFactory.build({
       ...cell2,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 2 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell3 = LocationFactory.build({
       ...cell3,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
   }
 

--- a/integration_tests/e2e/reactivate/location/wing/setupStubs.ts
+++ b/integration_tests/e2e/reactivate/location/wing/setupStubs.ts
@@ -21,6 +21,7 @@ export const location = LocationFactory.build({
   specialistCellTypes: [],
   status: 'INACTIVE',
   locationType: 'WING',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const landing1 = LocationFactory.build({
@@ -43,6 +44,7 @@ export const landing1 = LocationFactory.build({
   specialistCellTypes: [],
   status: 'INACTIVE',
   locationType: 'LANDING',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const landing2 = LocationFactory.build({
@@ -65,6 +67,7 @@ export const landing2 = LocationFactory.build({
   specialistCellTypes: [],
   status: 'INACTIVE',
   locationType: 'LANDING',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell1 = LocationFactory.build({
@@ -89,6 +92,7 @@ export const cell1 = LocationFactory.build({
   localName: null,
   specialistCellTypes: ['ACCESSIBLE_CELL', 'CONSTANT_SUPERVISION'],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell2 = LocationFactory.build({
@@ -113,6 +117,7 @@ export const cell2 = LocationFactory.build({
   localName: null,
   specialistCellTypes: [],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell3 = LocationFactory.build({
@@ -137,6 +142,7 @@ export const cell3 = LocationFactory.build({
   localName: null,
   specialistCellTypes: ['ACCESSIBLE_CELL', 'CONSTANT_SUPERVISION'],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export const cell4 = LocationFactory.build({
@@ -161,6 +167,7 @@ export const cell4 = LocationFactory.build({
   localName: null,
   specialistCellTypes: [],
   status: 'INACTIVE',
+  inactiveStatus: 'INACTIVE_MATCHING_CELL_CERT',
 })
 
 export function setupStubs(role: string, hasCertChange = true) {
@@ -176,30 +183,37 @@ export function setupStubs(role: string, hasCertChange = true) {
     stubLocation = LocationFactory.build({
       ...location,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 4 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubLanding1 = LocationFactory.build({
       ...landing1,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 2 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubLanding2 = LocationFactory.build({
       ...landing2,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 2 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell1 = LocationFactory.build({
       ...cell1,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell2 = LocationFactory.build({
       ...cell2,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell3 = LocationFactory.build({
       ...cell3,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
     stubCell4 = LocationFactory.build({
       ...cell4,
       currentCellCertificate: { ...location.currentCellCertificate, workingCapacity: 1 },
+      inactiveStatus: 'INACTIVE_TEMP',
     })
   }
 

--- a/server/routes/reactivate/location/steps.ts
+++ b/server/routes/reactivate/location/steps.ts
@@ -15,13 +15,13 @@ import SubmitCertificationApprovalRequest from '../../../commonTransactions/subm
 import NoCertChangeConfirm from '../../../controllers/reactivate/location/noCertChangeConfirm'
 import hasAnyCertCapacityChange from '../../../controllers/reactivate/location/util/hasAnyCertCapacityChange'
 
-function isTemporaryDeactivation(_req: FormWizard.Request, res: Response) {
+export function isTemporaryDeactivation(_req: FormWizard.Request, res: Response) {
   const { prisonConfiguration, decoratedLocation } = res.locals
   if (prisonConfiguration.certificationApprovalRequired !== 'ACTIVE') {
     return true
   }
 
-  return !(decoratedLocation.currentCellCertificate.workingCapacity === 0 && decoratedLocation.oldWorkingCapacity !== 0)
+  return decoratedLocation.inactiveStatus !== 'INACTIVE_MATCHING_CELL_CERT'
 }
 
 function wrapSetCellTypeController(path: string, step: FormWizard.Step) {

--- a/server/views/macros/inactiveLocationBanner.njk
+++ b/server/views/macros/inactiveLocationBanner.njk
@@ -10,8 +10,9 @@
   {% if location.deactivationReasonDescription %}
     {% set deactivatedReason = deactivatedReason + " - " + location.deactivationReasonDescription %}
   {% endif %}
-  {% set isCertifiedDeactivation = isCertActive and location.currentCellCertificate.workingCapacity === 0 and location.oldWorkingCapacity !== 0 %}
+  {% set isCertifiedDeactivation = isCertActive and location.inactiveStatus === 'INACTIVE_MATCHING_CELL_CERT' %}
   {% set isTemporaryDeactivation = not isCertifiedDeactivation and (not isCertActive or not location.pendingApprovalRequestId) %}
+  {% set canReactivate = canAccess('reactivate') and (not isCertifiedDeactivation or canAccess('certificate_change_request_create')) %}
 
   {% set inactiveHtml %}
     <span class="hmpps-inactive-location-banner">
@@ -110,7 +111,7 @@
 
     {% if not location.raw.status.includes('LOCKED_') %}
       {% if isCertActive %}
-        {% if canAccess('reactivate') %}
+        {% if canReactivate %}
           {{ govukButton({
             text: "Activate " + ("entire " if location.raw.locationType !== 'CELL') + (location.locationType | lower),
             classes: "govuk-!-margin-top-5 govuk-!-margin-right-1 govuk-!-margin-bottom-0",


### PR DESCRIPTION
Only show the reactivate button if it would not require a cert change or if the user is permitted to make a cert change request.

[MAP-3195](https://dsdmoj.atlassian.net/browse/MAP-3195)

[MAP-3195]: https://dsdmoj.atlassian.net/browse/MAP-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ