### PR TITLE
MAPA-100: Only show used for change link for normal accommodation

### DIFF
--- a/server/middleware/populateDecoratedResidentialSummary.test.ts
+++ b/server/middleware/populateDecoratedResidentialSummary.test.ts
@@ -50,6 +50,7 @@ describe('populateDecoratedResidentialSummary - Link Visibility Functions', () =
         prisonId: 'MDI',
         code: 'A-1-001',
         pathHierarchy: 'A-1-001',
+        accommodationTypes: ['NORMAL_ACCOMMODATION'],
       },
     }
     return { ...base, ...overrides } as DecoratedLocation
@@ -195,6 +196,30 @@ describe('populateDecoratedResidentialSummary - Link Visibility Functions', () =
       const request = createMockRequest(true)
 
       expect(showChangeUsedForLink(location, request)).toBe(false)
+    })
+
+    it('shows link for NORMAL_ACCOMMODATION location', () => {
+      const location = createMockLocation({ active: true })
+      location.accommodationTypes = ['NORMAL_ACCOMMODATION']
+      const request = createMockRequest(true)
+
+      expect(showChangeUsedForLink(location, request)).toBe(true)
+    })
+
+    it('does not show link for non-NORMAL_ACCOMMODATION location', () => {
+      const location = createMockLocation({ active: true })
+      location.raw.accommodationTypes = ['CARE_AND_SEPARATION']
+      const request = createMockRequest(true)
+
+      expect(showChangeUsedForLink(location, request)).toBe(false)
+    })
+
+    it('shows link for parent with at least one NORMAL_ACCOMMODATION location', () => {
+      const location = createMockLocation({ active: true })
+      location.raw.accommodationTypes = ['NORMAL_ACCOMMODATION', 'CARE_AND_SEPARATION']
+      const request = createMockRequest(true)
+
+      expect(showChangeUsedForLink(location, request)).toBe(true)
     })
   })
 

--- a/server/middleware/populateDecoratedResidentialSummary.ts
+++ b/server/middleware/populateDecoratedResidentialSummary.ts
@@ -60,6 +60,7 @@ export function showChangeUsedForLink(location: DecoratedLocation, req: Request)
   return (
     (location.active || location.status === 'DRAFT') &&
     !location.status.includes('LOCKED_') &&
+    location.raw.accommodationTypes.includes('NORMAL_ACCOMMODATION') &&
     req.canAccess('change_used_for')
   )
 }


### PR DESCRIPTION
Only show the "Used for" change link for:
- Individual cells with accommodation type: Normal accommodation
- Parent locations (e.g. Wing/Landing) that contain at least one child cell with accommodation type: Normal accommodation

[MAPA-100](https://dsdmoj.atlassian.net/browse/MAPA-100)

[MAPA-100]: https://dsdmoj.atlassian.net/browse/MAPA-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ