### PR TITLE
fix: use named params for requestSpecialistCellTypeChange

### DIFF
--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
@@ -533,14 +533,12 @@ export default class Confirm extends FormInitialStep {
       const { maxCapacity, workingCapacity, certifiedNormalAccommodation, specialistCellTypes } = locations[0]
 
       return (
-        await locationsService.requestSpecialistCellTypeChange(
-          systemToken,
-          locationId,
+        await locationsService.requestSpecialistCellTypeChange(systemToken, locationId, {
           specialistCellTypes,
           maxCapacity,
           workingCapacity,
           certifiedNormalAccommodation,
-        )
+        })
       ).id
     }
 

--- a/server/services/locationsService.test.ts
+++ b/server/services/locationsService.test.ts
@@ -446,7 +446,12 @@ describe('Locations service', () => {
 
   describe('requestSpecialistCellTypeChange', () => {
     it('calls the correct client function', async () => {
-      await locationsService.requestSpecialistCellTypeChange('token', 'location-id', ['PINEAPPLE_CELL'], 1, 2, 3)
+      await locationsService.requestSpecialistCellTypeChange('token', 'location-id', {
+        specialistCellTypes: ['PINEAPPLE_CELL'],
+        workingCapacity: 1,
+        maxCapacity: 2,
+        certifiedNormalAccommodation: 3,
+      })
 
       expect(locationsApiClient.certification.location.specialistCellTypeChange).toHaveBeenCalledWith('token', null, {
         locationId: 'location-id',

--- a/server/services/locationsService.ts
+++ b/server/services/locationsService.ts
@@ -90,18 +90,17 @@ export default class LocationsService {
   async requestSpecialistCellTypeChange(
     token: string,
     locationId: string,
-    specialistCellTypes: string[],
-    workingCapacity: number,
-    maxCapacity: number,
-    certifiedNormalAccommodation: number,
+    data: {
+      specialistCellTypes: string[]
+      workingCapacity: number
+      maxCapacity: number
+      certifiedNormalAccommodation: number
+    },
   ) {
     return this.locationsApiClient.certification.location.specialistCellTypeChange(token, null, {
       locationId,
-      specialistCellTypes,
-      workingCapacity,
-      maxCapacity,
-      certifiedNormalAccommodation,
       reasonForChange: null,
+      ...data,
     })
   }
 


### PR DESCRIPTION
Max cap and working cap were the wrong way round so I have changed it to use named params to avoid any accidents in future.

[MAPA-56](https://dsdmoj.atlassian.net/browse/MAPA-56)

[MAPA-56]: https://dsdmoj.atlassian.net/browse/MAPA-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ