### PR TITLE
fix: don't filter cert reviewer users by active caseload

### DIFF
--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
@@ -567,6 +567,7 @@ describe('Confirm', () => {
           'token',
           'TST',
           notificationGroups.requestReceivedUsers,
+          false,
         )
         expect(notificationHelpers.getUserEmails).toHaveBeenNthCalledWith(
           i * 2 + 2,

--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
@@ -568,7 +568,7 @@ export default class Confirm extends FormInitialStep {
 
           // Send notifications to both sets of relevant cert roles
           const [requestReceivedAddresses, requestSubmittedEmails] = await Promise.all([
-            getUserEmails(manageUsersService, systemToken, prisonId, notificationGroups.requestReceivedUsers),
+            getUserEmails(manageUsersService, systemToken, prisonId, notificationGroups.requestReceivedUsers, false),
             getUserEmails(manageUsersService, systemToken, prisonId, notificationGroups.requestSubmittedUsers),
           ])
 

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -87,9 +87,16 @@ describe('manageUsersApiClient', () => {
     testCall('get', '/users/USERNAME', true, () => apiClient.users.get, { username: 'USERNAME' })
     testCall(
       'getUsersByCaseload',
-      '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&activeCaseload=CASELOAD&accessRoles=ROLE&size=50&page=1',
+      '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&caseload=CASELOAD&accessRoles=ROLE&size=50&page=1',
       false,
       () => apiClient.users.getUsersByCaseload,
+      { caseload: 'CASELOAD', accessRoles: 'ROLE', page: '1', size: '50' },
+    )
+    testCall(
+      'getUsersByActiveCaseload',
+      '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&activeCaseload=CASELOAD&accessRoles=ROLE&size=50&page=1',
+      false,
+      () => apiClient.users.getUsersByActiveCaseload,
       { caseload: 'CASELOAD', accessRoles: 'ROLE', page: '1', size: '50' },
     )
   })

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -75,6 +75,13 @@ export default class ManageUsersApiClient extends BaseApiClient {
       PaginatedUsers,
       { caseload: string; accessRoles: string; page: string; size: string }
     >({
+      path: '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&caseload=:caseload&accessRoles=:accessRoles&page=:page&size=:size',
+      requestType: 'get',
+    }),
+    getUsersByActiveCaseload: this.apiCall<
+      PaginatedUsers,
+      { caseload: string; accessRoles: string; page: string; size: string }
+    >({
       path: '/prisonusers/search?inclusiveRoles=true&status=ACTIVE&activeCaseload=:caseload&accessRoles=:accessRoles&page=:page&size=:size',
       requestType: 'get',
     }),

--- a/server/services/manageUsersService.test.ts
+++ b/server/services/manageUsersService.test.ts
@@ -35,6 +35,19 @@ describe('Manage users service', () => {
           ) => Promise<PaginatedUsers>
         >,
       ),
+      getUsersByActiveCaseload: Object.assign(
+        jest.fn() as jest.MockedFunction<
+          (
+            token: string,
+            parameters: {
+              caseload: string
+              accessRoles: string
+              page: string
+              size: string
+            },
+          ) => Promise<PaginatedUsers>
+        >,
+      ),
     }
 
     service = new ManageUsersService(apiClient)
@@ -80,13 +93,19 @@ describe('Manage users service', () => {
       apiClient.users.getUsersByCaseload.mockImplementation((_token, { page }) => {
         if (page === '0') {
           return Promise.resolve({
-            content: [{ username: 'joe1', email: 'joe1@test.com' }],
+            content: [
+              { username: 'joe1', email: 'joe1@test.com' },
+              { username: 'joe2', email: 'joe2@test.com' },
+            ],
             totalPages: 2,
           })
         }
         if (page === '1') {
           return Promise.resolve({
-            content: [{ username: 'joe2', email: 'joe2@test.com' }],
+            content: [
+              { username: 'joe3', email: 'joe3@test.com' },
+              { username: 'joe4', email: 'joe4@test.com' },
+            ],
             totalPages: 2,
           })
         }
@@ -95,6 +114,7 @@ describe('Manage users service', () => {
 
       const result = await service.getAllUsersByCaseload('token', 'CASELOAD', ['ROLE'])
 
+      expect(apiClient.users.getUsersByCaseload).toHaveBeenCalledTimes(2)
       expect(apiClient.users.getUsersByCaseload).toHaveBeenCalledWith('token', {
         caseload: 'CASELOAD',
         accessRoles: 'ROLE',
@@ -112,8 +132,121 @@ describe('Manage users service', () => {
         content: [
           { username: 'joe1', email: 'joe1@test.com' },
           { username: 'joe2', email: 'joe2@test.com' },
+          { username: 'joe3', email: 'joe3@test.com' },
+          { username: 'joe4', email: 'joe4@test.com' },
         ],
         totalPages: 2,
+      })
+    })
+
+    it('calls the API only once when there is only one page', async () => {
+      // @ts-expect-error @ts-ignore
+      apiClient.users.getUsersByCaseload.mockResolvedValue({
+        content: [
+          { username: 'joe1', email: 'joe1@test.com' },
+          { username: 'joe2', email: 'joe2@test.com' },
+        ],
+        totalPages: 1,
+      })
+
+      const result = await service.getAllUsersByCaseload('token', 'CASELOAD', ['ROLE'])
+
+      expect(apiClient.users.getUsersByCaseload).toHaveBeenCalledTimes(1)
+      expect(apiClient.users.getUsersByCaseload).toHaveBeenCalledWith('token', {
+        caseload: 'CASELOAD',
+        accessRoles: 'ROLE',
+        page: '0',
+        size: '50',
+      })
+
+      expect(result).toEqual({
+        content: [
+          { username: 'joe1', email: 'joe1@test.com' },
+          { username: 'joe2', email: 'joe2@test.com' },
+        ],
+        totalPages: 1,
+      })
+    })
+  })
+
+  describe('getAllUsersByActiveCaseload', () => {
+    it('calls the correct client function, gets all pages and concatenates users', async () => {
+      // @ts-expect-error @ts-ignore
+      apiClient.users.getUsersByActiveCaseload.mockImplementation((_token, { page }) => {
+        if (page === '0') {
+          return Promise.resolve({
+            content: [
+              { username: 'joe1', email: 'joe1@test.com' },
+              { username: 'joe2', email: 'joe2@test.com' },
+            ],
+            totalPages: 2,
+          })
+        }
+        if (page === '1') {
+          return Promise.resolve({
+            content: [
+              { username: 'joe3', email: 'joe3@test.com' },
+              { username: 'joe4', email: 'joe4@test.com' },
+            ],
+            totalPages: 2,
+          })
+        }
+        return Promise.resolve({ content: [], totalPages: 2 })
+      })
+
+      const result = await service.getAllUsersByActiveCaseload('token', 'CASELOAD', ['ROLE'])
+
+      expect(apiClient.users.getUsersByActiveCaseload).toHaveBeenCalledTimes(2)
+      expect(apiClient.users.getUsersByActiveCaseload).toHaveBeenCalledWith('token', {
+        caseload: 'CASELOAD',
+        accessRoles: 'ROLE',
+        page: '0',
+        size: '50',
+      })
+      expect(apiClient.users.getUsersByActiveCaseload).toHaveBeenCalledWith('token', {
+        caseload: 'CASELOAD',
+        accessRoles: 'ROLE',
+        page: '1',
+        size: '50',
+      })
+
+      expect(result).toEqual({
+        content: [
+          { username: 'joe1', email: 'joe1@test.com' },
+          { username: 'joe2', email: 'joe2@test.com' },
+          { username: 'joe3', email: 'joe3@test.com' },
+          { username: 'joe4', email: 'joe4@test.com' },
+        ],
+        totalPages: 2,
+      })
+    })
+
+    it('calls the API only once when there is only one page', async () => {
+      // @ts-expect-error @ts-ignore
+      apiClient.users.getUsersByActiveCaseload.mockResolvedValue({
+        content: [
+          { username: 'joe1', email: 'joe1@test.com' },
+          { username: 'joe2', email: 'joe2@test.com' },
+        ],
+        totalPages: 1,
+      })
+
+      const result = await service.getAllUsersByActiveCaseload('token', 'CASELOAD', ['ROLE'])
+
+      expect(apiClient.users.getUsersByActiveCaseload).toHaveBeenCalledTimes(1)
+      expect(apiClient.users.getUsersByActiveCaseload).toHaveBeenCalledWith('token', {
+        caseload: 'CASELOAD',
+        accessRoles: 'ROLE',
+        page: '0',
+        size: '50',
+      })
+
+      expect(result).toEqual({
+        content: [
+          { username: 'joe1', email: 'joe1@test.com' },
+          { username: 'joe2', email: 'joe2@test.com' },
+        ],
+        totalPages: 1,
       })
     })
   })

--- a/server/services/manageUsersService.ts
+++ b/server/services/manageUsersService.ts
@@ -27,14 +27,39 @@ export default class ManageUsersService {
     accessRoles: string[],
     size = 50,
   ): Promise<PaginatedUsers> {
-    const firstPage: PaginatedUsers = await this.getPagedUsersByCaseload(token, caseload, accessRoles, 0, size)
+    const apiCall = this.manageUsersApiClient.users.getUsersByCaseload
+    return this.getAllUsersByFilter(token, caseload, accessRoles, size, apiCall)
+  }
+
+  async getAllUsersByActiveCaseload(
+    token: string,
+    caseload: string,
+    accessRoles: string[],
+    size = 50,
+  ): Promise<PaginatedUsers> {
+    const apiCall = this.manageUsersApiClient.users.getUsersByActiveCaseload
+    return this.getAllUsersByFilter(token, caseload, accessRoles, size, apiCall)
+  }
+
+  async getAllUsersByFilter(
+    token: string,
+    caseload: string,
+    accessRoles: string[],
+    size = 50,
+    apiCall = this.manageUsersApiClient.users.getUsersByCaseload,
+  ): Promise<PaginatedUsers> {
+    const firstPage: PaginatedUsers = await this.getPagedUsersByCaseload(token, caseload, accessRoles, 0, size, apiCall)
     const { totalPages } = firstPage
+    const responses: PaginatedUsers[] = [firstPage]
 
-    const pagedResponses = Array.from({ length: totalPages }, (_, page) =>
-      this.getPagedUsersByCaseload(token, caseload, accessRoles, page, size),
-    )
+    if (totalPages > 1) {
+      const pagePromises = Array.from({ length: totalPages - 1 }, (_, page) =>
+        this.getPagedUsersByCaseload(token, caseload, accessRoles, page + 1, size, apiCall),
+      )
+      const pages = await Promise.all(pagePromises)
+      responses.push(...pages)
+    }
 
-    const responses: PaginatedUsers[] = await Promise.all(pagedResponses)
     const allUsers: UserAccount[] = responses.flatMap(response => response.content)
 
     return {
@@ -49,8 +74,9 @@ export default class ManageUsersService {
     accessRoles: string[],
     page: number,
     size: number,
+    apiCall: typeof this.manageUsersApiClient.users.getUsersByCaseload,
   ): Promise<PaginatedUsers> {
-    return this.manageUsersApiClient.users.getUsersByCaseload(token, {
+    return apiCall(token, {
       caseload,
       accessRoles: accessRoles.join(','),
       page: page.toString(),

--- a/server/services/notificationService.test.ts
+++ b/server/services/notificationService.test.ts
@@ -34,7 +34,7 @@ describe('NotificationService', () => {
 
   const baseNotificationDetails: NotificationDetails = {
     type: NotificationType.REQUEST_RECEIVED,
-    emailAddresses: ['user@example.com'],
+    emailAddresses: ['user1@example.com', 'user2@example.com'],
     establishment: 'Test Establishment',
     submittedBy: 'John Doe',
   }
@@ -49,7 +49,7 @@ describe('NotificationService', () => {
     })
 
     const baseDetails: Partial<NotificationDetails> = {
-      emailAddresses: ['user@example.com'],
+      emailAddresses: ['user1@example.com', 'user2@example.com'],
       establishment: 'Test Establishment',
       submittedBy: 'John Doe',
       location: 'Test Location',
@@ -109,17 +109,21 @@ describe('NotificationService', () => {
     ]
 
     testCases.forEach(({ type, expectedPersonalisation }) => {
-      it(`should send ${type} email to actual recipient`, async () => {
+      it(`should send ${type} emails to both recipients`, async () => {
         const details: NotificationDetails = {
           ...baseDetails,
           type,
-          emailAddress: ['user@example.com'],
+          emailAddresses: ['user1@example.com', 'user2@example.com'],
         } as NotificationDetails
 
         const service = new NotificationService(mockNotifyClient)
         await service.notify(details)
 
-        expect(mockSendEmail).toHaveBeenCalledWith(config.email.templates[`CHANGE_${type}`], 'user@example.com', {
+        expect(mockSendEmail).toHaveBeenCalledTimes(2)
+        expect(mockSendEmail).toHaveBeenCalledWith(config.email.templates[`CHANGE_${type}`], 'user1@example.com', {
+          personalisation: expectedPersonalisation,
+        })
+        expect(mockSendEmail).toHaveBeenCalledWith(config.email.templates[`CHANGE_${type}`], 'user2@example.com', {
           personalisation: expectedPersonalisation,
         })
       })
@@ -134,10 +138,10 @@ describe('NotificationService', () => {
 
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Email failed to send'))
     expect(logger.info).toHaveBeenCalledWith(
-      'Starting batch send for Test Establishment. Sending 1 REQUEST_RECEIVED emails to GovUK Notify.',
+      'Starting batch send for Test Establishment. Sending 2 REQUEST_RECEIVED emails to GovUK Notify.',
     )
     expect(logger.info).toHaveBeenCalledWith(
-      'Finished batch send for Test Establishment. Sent 0/1 REQUEST_RECEIVED emails to GovUK Notify.',
+      'Finished batch send for Test Establishment. Sent 1/2 REQUEST_RECEIVED emails to GovUK Notify.',
     )
     expect(logger.info).toHaveBeenCalledWith(
       'Failed to send 1 REQUEST_RECEIVED emails for Test Establishment. Check GovUK Notify dashboard for details.',

--- a/server/utils/notificationHelpers.test.ts
+++ b/server/utils/notificationHelpers.test.ts
@@ -1,0 +1,32 @@
+import { getUserEmails } from './notificationHelpers'
+import ManageUsersService from '../services/manageUsersService'
+
+describe('getUserEmails', () => {
+  const manageUsersService = new ManageUsersService(null) as jest.Mocked<ManageUsersService>
+  manageUsersService.getAllUsersByActiveCaseload = jest.fn().mockResolvedValue({
+    content: [
+      { username: 'joe1', email: 'joe1@test.com' },
+      { username: 'joe2', email: 'joe2@test.com' },
+      { username: 'joey_no_email', email: null },
+    ],
+    totalPages: 2,
+  })
+  manageUsersService.getAllUsersByCaseload = jest.fn().mockResolvedValue({
+    content: [
+      { username: 'joe3', email: 'joe3@test.com' },
+      { username: 'joe4', email: 'joe4@test.com' },
+      { username: 'joey_no_email', email: null },
+    ],
+    totalPages: 2,
+  })
+
+  it('returns the correct list of users with active caseload', async () => {
+    const result = await getUserEmails(manageUsersService, 'token', 'TST', ['RESI__CERT_REVIEWER'])
+    expect(result).toEqual(['joe1@test.com', 'joe2@test.com'])
+  })
+
+  it('returns the correct list of users with caseload', async () => {
+    const result = await getUserEmails(manageUsersService, 'token', 'TST', ['RESI__CERT_REVIEWER'], false)
+    expect(result).toEqual(['joe3@test.com', 'joe4@test.com'])
+  })
+})

--- a/server/utils/notificationHelpers.ts
+++ b/server/utils/notificationHelpers.ts
@@ -8,8 +8,12 @@ export async function getUserEmails(
   systemToken: string,
   prisonId: string,
   roles: string[],
+  onlyActiveCaseload = true,
 ): Promise<string[]> {
-  const users: PaginatedUsers = await manageUsersService.getAllUsersByCaseload(systemToken, prisonId, roles)
+  const getterFunction = onlyActiveCaseload
+    ? manageUsersService.getAllUsersByActiveCaseload
+    : manageUsersService.getAllUsersByCaseload
+  const users: PaginatedUsers = await getterFunction(systemToken, prisonId, roles)
   const emails = users.content.map(user => user.email).filter(email => email)
   return [...new Set(emails)]
 }


### PR DESCRIPTION
The "request received" emails should go to everybody with the cert reviewer role and the relevant caseload. It does not need to be their active caseload.

Other emails are still only sent to people with the relevant active caseload.

MAPA-120