### PR TITLE
fix: Avoid unbound `this` when calling managa users API functions

### DIFF
--- a/server/utils/notificationHelpers.ts
+++ b/server/utils/notificationHelpers.ts
@@ -10,10 +10,8 @@ export async function getUserEmails(
   roles: string[],
   onlyActiveCaseload = true,
 ): Promise<string[]> {
-  const getterFunction = onlyActiveCaseload
-    ? manageUsersService.getAllUsersByActiveCaseload
-    : manageUsersService.getAllUsersByCaseload
-  const users: PaginatedUsers = await getterFunction(systemToken, prisonId, roles)
+  const getterFunction = onlyActiveCaseload ? 'getAllUsersByActiveCaseload' : 'getAllUsersByCaseload'
+  const users: PaginatedUsers = await manageUsersService[getterFunction](systemToken, prisonId, roles)
   const emails = users.content.map(user => user.email).filter(email => email)
   return [...new Set(emails)]
 }


### PR DESCRIPTION
Some errors are occurring and the logs suggest that it is trying to call `manageUsersApiClient` on `undefined` in the manage users service, which means that `this` must be undefined. This is probably due to the recent change which dynamically calls one of the methods of the service and it is losing its binding via `this` to the instance of the service.

I can't seem to replicate this locally so I haven't been able to write a test for it, but it will be tested in dev ASAP.

[MAPA-126](https://dsdmoj.atlassian.net/browse/MAPA-126)

[MAPA-126]: https://dsdmoj.atlassian.net/browse/MAPA-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ