### PR TITLE
MAPA-115 Add capacity management dashboard tile to Locations landing page

### DIFF
--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -84,6 +84,33 @@ context('Index', () => {
     })
   })
 
+  context('With RESI__CERT_VIEWER role', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      AuthStubber.stub.stubSignIn({ roles: ['RESI__CERT_VIEWER'] })
+      LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+      ManageUsersApiStubber.stub.stubManageUsersMe()
+      ManageUsersApiStubber.stub.stubManageUsersMeCaseloads()
+    })
+
+    it('Displays the capacity management dashboard tile linking to the dashboard', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+
+      indexPage.cards.cellCertificate().contains('Cell certificate')
+      indexPage.cards.capacityManagementDashboard().contains('Capacity management dashboard')
+      indexPage.cards
+        .capacityManagementDashboard()
+        .contains('View a summary of cell certificates and change requests for every establishment.')
+      indexPage.cards
+        .capacityManagementDashboard()
+        .find('a')
+        .should('have.attr', 'href', '/capacity-management-dashboard')
+
+      cy.screenshot('capacity-management-dashboard-tile', { capture: 'viewport' })
+    })
+  })
+
   context('With MANAGE_RES_LOCATIONS_OP_CAP role', () => {
     beforeEach(() => {
       cy.task('reset')

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -14,6 +14,7 @@ export default class IndexPage extends Page {
     manageLocations: (): PageElement => cy.get('[data-qa=manage-locations-card]'),
     inactiveCells: (): PageElement => cy.get('[data-qa=inactive-cells-card]'),
     cellCertificate: (): PageElement => cy.get('[data-qa=cell-certificate-card]'),
+    capacityManagementDashboard: (): PageElement => cy.get('[data-qa=capacity-management-dashboard-card]'),
     archivedLocations: (): PageElement => cy.get('[data-qa=archived-locations-card]'),
     locationHistory: (): PageElement => cy.get('[data-qa=location-history-card]'),
     adminster: (): PageElement => cy.get('[data-qa=admin-card]'),

--- a/server/middleware/populateCards.ts
+++ b/server/middleware/populateCards.ts
@@ -74,6 +74,14 @@ export default function populateCards(locationsService: LocationsService) {
       },
       {
         clickable: true,
+        visible: req.canAccess('certificate_view_management'),
+        heading: 'Capacity management dashboard',
+        href: '/capacity-management-dashboard',
+        description: 'View a summary of cell certificates and change requests for every establishment.',
+        'data-qa': 'capacity-management-dashboard-card',
+      },
+      {
+        clickable: true,
         visible: req.canAccess('administer_residential'),
         heading: 'Admin',
         href: '/admin',

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -89,10 +89,38 @@ describe('GET /', () => {
     expect(res.text).toContain('Archived locations')
     expect(res.text).toContain('Cell certificate')
 
+    // MANAGE_RESIDENTIAL_LOCATIONS does not grant certificate_view_management
+    expect(res.text).not.toContain('Capacity management dashboard')
+
     expect(auditService.logPageView).toHaveBeenCalledWith(Page.INDEX, {
       who: user.username,
       correlationId: expect.any(String),
     })
+  })
+
+  it('should render the "Capacity management dashboard" tile for a certificate viewer', async () => {
+    locationsService.getPrisonConfiguration.mockResolvedValue({
+      prisonId: 'TST',
+      resiLocationServiceActive: 'ACTIVE',
+      nonResiServiceActive: 'INACTIVE',
+      includeSegregationInRollCount: 'INACTIVE',
+      certificationApprovalRequired: 'ACTIVE',
+    })
+
+    app = appWithAllRoutes({
+      services: {
+        auditService,
+        locationsService,
+      },
+      userSupplier: () => ({ ...user, userRoles: ['RESI__CERT_VIEWER'] }),
+    })
+
+    auditService.logPageView.mockResolvedValue(null)
+    const res = await request(app).get('/')
+
+    expect(res.text).toContain('Capacity management dashboard')
+    expect(res.text).toContain('View a summary of cell certificates and change requests for every establishment.')
+    expect(res.text).toContain('/capacity-management-dashboard')
   })
 
   it('should render permission message when resi service is active but user has no residential role', async () => {


### PR DESCRIPTION
## What
Adds a **Capacity management dashboard** tile to the Residential locations group on the Locations landing page, giving certificate viewers an entry point to the dashboard.

> **Depends on #653 (MAPA-114)** — the tile links to `/capacity-management-dashboard`, which is added by that PR. Merge after (or together with) #653.

## Changes
- New card in `server/middleware/populateCards.ts`:
  - H2 "Capacity management dashboard", body "View a summary of cell certificates and change requests for every establishment.", links to `/capacity-management-dashboard`
  - Visible when the user has the `certificate_view_management` permission — the same gate as the dashboard route, so the tile and page stay in lockstep (same `req.canAccess(...)` pattern the Admin card uses)
- Home page route tests (`server/routes/index.test.ts`): tile shown to certificate viewers, hidden from users without the permission
- Cypress coverage in `integration_tests/e2e/index.cy.ts` plus an index page-object accessor

## Acceptance criteria
- [x] A certificate viewer sees the tile on the Locations home screen
- [x] Clicking it goes to the dashboard
- [x] H2 = "Capacity management dashboard"; body = "View a summary of cell certificates and change requests for every establishment."
- [x] Only users with the certificate-viewer permission see it

## Testing
- `npm run typecheck`, `lint` and full `jest` suite pass
- Cypress index spec verifies the tile content and link for a `RESI__CERT_VIEWER` user