### PR TITLE
MAPB-537 Stabilise Cypress CI: enable Chrome memory management and spec retries

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -39,6 +39,12 @@ function preprocessorOptions() {
 
 export default defineConfig({
   chromeWebSecurity: false,
+  // Prevent headless Chrome from accumulating memory and hanging the runner in CI,
+  // which intermittently stalls a single Cypress split container until the job timeout.
+  experimentalMemoryManagement: true,
+  numTestsKeptInMemory: 0,
+  // Re-run flaky specs in CI (e.g. WireMock sign-in races) instead of failing the build.
+  retries: { runMode: 2, openMode: 0 },
   fixturesFolder: 'integration_tests/fixtures',
   screenshotsFolder: 'integration_tests/screenshots',
   videosFolder: 'integration_tests/videos',


### PR DESCRIPTION
## What

Adds three Cypress config options in `cypress.config.ts`:

- `experimentalMemoryManagement: true`
- `numTestsKeptInMemory: 0`
- `retries: { runMode: 2, openMode: 0 }`

## Why

A single Cypress split container (consistently container 7, which carries the heavy `reactivate/cells` flow) intermittently **hangs until the CI job timeout** while every other container passes in minutes. This is a flaky, pre-existing problem — it reproduces on commits that predate any recent feature work, and the *same commit* passes in one run and hangs in another. No Cypress command can hang that long (page-load and task timeouts are 60s), so the browser itself is becoming unresponsive, the classic symptom of headless Chrome memory build-up in CI.

`experimentalMemoryManagement` + `numTestsKeptInMemory: 0` is Cypress's remedy for that hang class. The `retries` cover residual flakes such as the occasional WireMock sign-in race (`getSignInUrl` returning an empty request journal) so a single flaky spec re-runs instead of failing the pipeline.

## Testing in isolation

Raised as a standalone branch off main so the effect on CI stability can be observed without other in-flight changes.