### PR TITLE
fix: Button text typo for change cell type

### DIFF
--- a/server/controllers/changeCellType/index.test.ts
+++ b/server/controllers/changeCellType/index.test.ts
@@ -205,7 +205,7 @@ describe('SetCellType', () => {
         const locals = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
         expect(locals.title).toBe('Select special cell type')
         expect(locals.titleCaption).toBe('Cell A-1-001')
-        expect(locals.buttonText).toBe('Save cell types')
+        expect(locals.buttonText).toBe('Save cell type')
         expect(deepReq.form.options.fields.specialistCellTypes.component).toBe('govukRadios')
         expect(deepReq.form.options.fields.specialistCellTypes.multiple).toBe(false)
         expect(locals.fields).toEqual({

--- a/server/controllers/changeCellType/index.ts
+++ b/server/controllers/changeCellType/index.ts
@@ -33,7 +33,7 @@ export default class ChangeCellType extends FormInitialStep {
 
     locals.title = `Select ${affectsCapacity ? 'special' : 'normal'} cell type`
     locals.titleCaption = `Cell ${res.locals.decoratedLocation.pathHierarchy}`
-    locals.buttonText = 'Save cell types'
+    locals.buttonText = affectsCapacity ? 'Save cell type' : 'Save cell types'
     req.form.options.fields.specialistCellTypes.component = affectsCapacity ? 'govukRadios' : 'govukCheckboxes'
     req.form.options.fields.specialistCellTypes.multiple = !affectsCapacity
 


### PR DESCRIPTION
Tweak button text for change cell type depending on whether it's normal or special cell type.

[MAPA-54](https://dsdmoj.atlassian.net/browse/MAPA-54)

[MAPA-54]: https://dsdmoj.atlassian.net/browse/MAPA-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ