### PR TITLE
MAPA-115 Restrict capacity management dashboard to Certificate Viewers

### DIFF
--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -129,6 +129,25 @@ context('Index', () => {
       indexPage.cards.inactiveCells().contains('View all inactive cells')
       indexPage.cards.archivedLocations().contains('Archived locations')
       indexPage.cards.cellCertificate().contains('Cell certificate')
+      indexPage.cards.capacityManagementDashboard().should('not.exist')
+    })
+  })
+
+  context('With RESI__CERT_REVIEWER role', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      AuthStubber.stub.stubSignIn({ roles: ['RESI__CERT_REVIEWER'] })
+      LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+      ManageUsersApiStubber.stub.stubManageUsersMe()
+      ManageUsersApiStubber.stub.stubManageUsersMeCaseloads()
+    })
+
+    it('does not display the capacity management dashboard tile', () => {
+      cy.signIn()
+      const indexPage = Page.verifyOnPage(IndexPage)
+
+      indexPage.cards.cellCertificate().contains('Cell certificate')
+      indexPage.cards.capacityManagementDashboard().should('not.exist')
     })
   })
 })

--- a/server/lib/permissions.test.ts
+++ b/server/lib/permissions.test.ts
@@ -13,7 +13,6 @@ describe('rolesToPermissions', () => {
     expect(rolesToPermissions(['MANAGE_RES_LOCATIONS_OP_CAP']).sort()).toEqual([
       'certificate_change_request_create',
       'certificate_change_request_withdraw',
-      'certificate_view_management',
       'change_cell_capacity',
       'change_door_number',
       'change_local_name',
@@ -34,10 +33,7 @@ describe('rolesToPermissions', () => {
   })
 
   it('returns the correct permissions for RESI__CERT_REVIEWER', () => {
-    expect(rolesToPermissions(['RESI__CERT_REVIEWER']).sort()).toEqual([
-      'certificate_change_request_review',
-      'certificate_view_management',
-    ])
+    expect(rolesToPermissions(['RESI__CERT_REVIEWER']).sort()).toEqual(['certificate_change_request_review'])
   })
 
   it('returns the correct permissions for RESI__CERT_VIEWER', () => {

--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -6,7 +6,6 @@ const certificateViewerPermissions: string[] = ['certificate_view_management']
 
 const certificateAdministratorPermissions: string[] = [
   ...cellStatusManagerPermissions,
-  ...certificateViewerPermissions,
   'change_cell_capacity',
   'change_door_number',
   'change_local_name',
@@ -24,7 +23,7 @@ const certificateAdministratorPermissions: string[] = [
   'set_cell_type',
 ]
 
-const certificateReviewerPermissions: string[] = [...certificateViewerPermissions, 'certificate_change_request_review']
+const certificateReviewerPermissions: string[] = ['certificate_change_request_review']
 
 const administerResLocationsPermissions: string[] = ['administer_residential']
 

--- a/server/routes/capacityManagementDashboard.test.ts
+++ b/server/routes/capacityManagementDashboard.test.ts
@@ -19,6 +19,16 @@ const certificateViewer: HmppsUser = {
   userRoles: ['RESI__CERT_VIEWER'],
 }
 
+const certificateReviewer: HmppsUser = {
+  ...user,
+  userRoles: ['RESI__CERT_REVIEWER'],
+}
+
+const certificateAdministrator: HmppsUser = {
+  ...user,
+  userRoles: ['MANAGE_RES_LOCATIONS_OP_CAP'],
+}
+
 let app: Express
 
 const buildApp = (userSupplier: () => HmppsUser) =>
@@ -75,6 +85,18 @@ describe('GET /capacity-management-dashboard', () => {
     app = buildApp(() => user)
 
     // protectRoute raises a "Missing permission" 403, which the error handler turns into a sign-out redirect
+    return request(app).get('/capacity-management-dashboard').expect(302).expect('Location', '/sign-out')
+  })
+
+  it('denies access to a certificate reviewer', () => {
+    app = buildApp(() => certificateReviewer)
+
+    return request(app).get('/capacity-management-dashboard').expect(302).expect('Location', '/sign-out')
+  })
+
+  it('denies access to a certificate administrator', () => {
+    app = buildApp(() => certificateAdministrator)
+
     return request(app).get('/capacity-management-dashboard').expect(302).expect('Location', '/sign-out')
   })
 })

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -123,6 +123,32 @@ describe('GET /', () => {
     expect(res.text).toContain('/capacity-management-dashboard')
   })
 
+  it.each([['RESI__CERT_REVIEWER'], ['MANAGE_RES_LOCATIONS_OP_CAP']])(
+    'should not render the "Capacity management dashboard" tile for the %s role',
+    async role => {
+      locationsService.getPrisonConfiguration.mockResolvedValue({
+        prisonId: 'TST',
+        resiLocationServiceActive: 'ACTIVE',
+        nonResiServiceActive: 'INACTIVE',
+        includeSegregationInRollCount: 'INACTIVE',
+        certificationApprovalRequired: 'ACTIVE',
+      })
+
+      app = appWithAllRoutes({
+        services: {
+          auditService,
+          locationsService,
+        },
+        userSupplier: () => ({ ...user, userRoles: [role] }),
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      const res = await request(app).get('/')
+
+      expect(res.text).not.toContain('Capacity management dashboard')
+    },
+  )
+
   it('should render permission message when resi service is active but user has no residential role', async () => {
     locationsService.getPrisonConfiguration.mockResolvedValue({
       prisonId: 'TST',


### PR DESCRIPTION
## Why
MAPA-115 was reopened because the role permission on the capacity management dashboard is incorrect. The tile (Locations home page) and the `/capacity-management-dashboard` page were visible to **Certificate reviewers** and **Certificate administrators** as well as **Certificate viewers**. Only **Certificate Viewer** (`RESI__CERT_VIEWER`) users should see the tile and access the dashboard.

## Root cause
The `certificate_view_management` permission (the only gate on the tile and route) was defined in `certificateViewerPermissions` and spread into both `certificateReviewerPermissions` and `certificateAdministratorPermissions`, so all three roles inherited it. The permission is used nowhere else in the codebase.

## Changes
- `server/lib/permissions.ts` — remove the `...certificateViewerPermissions` spread from the reviewer and administrator permission sets, making `certificate_view_management` exclusive to `RESI__CERT_VIEWER`. The existing tile (`populateCards.ts`) and route guard (`index.ts`) checks now resolve to viewers only.
- `server/lib/permissions.test.ts` — update reviewer/administrator expectations.
- `server/routes/capacityManagementDashboard.test.ts` — add denial tests for reviewer and administrator.
- `server/routes/index.test.ts` — add negative tile-visibility tests for reviewer and administrator.
- `integration_tests/e2e/index.cy.ts` — add negative assertions for the administrator and reviewer roles.

## Testing
- Affected unit suites pass; full `npm test` runs via pre-commit hook.
- `npm run typecheck` and `npm run lint` clean.