### PR TITLE
MAPA-134 Fix notification link 'undefined' for deactivation change requests

### DIFF
--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
@@ -508,7 +508,12 @@ describe('Confirm', () => {
       updateCellSanitation: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'CELL_SANITATION-id' } as any),
       updateCellMark: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'CELL_MARK-id' } as any),
       requestReactivation: jest.fn().mockResolvedValue({ id: 'REACTIVATION-id' } as any),
-      deactivateTemporary: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'DEACTIVATION-id' } as any),
+      // Deactivation cascades: the API returns the deactivated location plus its sub-locations,
+      // each carrying the same pendingApprovalRequestId.
+      deactivateTemporary: jest.fn().mockResolvedValue([
+        { id: 'deactivationLocationId', pendingApprovalRequestId: 'DEACTIVATION-id' },
+        { id: 'deactivationLocationId-cell-1', pendingApprovalRequestId: 'DEACTIVATION-id' },
+      ] as any),
     } as unknown as jest.Mocked<LocationsService>
     deepReq = {
       form: {

--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
@@ -577,18 +577,21 @@ export default class Confirm extends FormInitialStep {
     }
 
     if (approvalType === 'DEACTIVATION') {
-      return (
-        await locationsService.deactivateTemporary(
-          systemToken,
-          locationId,
-          deactivatedReason,
-          deactivationReasonDescription,
-          proposedReactivationDate,
-          planetFmReference,
-          true,
-          reasonForChange,
-        )
-      ).pendingApprovalRequestId
+      // Deactivation cascades, so the API returns the deactivated location plus every
+      // sub-location. Each carries the same pendingApprovalRequestId, so read it from the
+      // requested location (falling back to the first entry if ordering ever changes).
+      const deactivatedLocations = await locationsService.deactivateTemporary(
+        systemToken,
+        locationId,
+        deactivatedReason,
+        deactivationReasonDescription,
+        proposedReactivationDate,
+        planetFmReference,
+        true,
+        reasonForChange,
+      )
+
+      return (deactivatedLocations.find(l => l.id === locationId) ?? deactivatedLocations[0])?.pendingApprovalRequestId
     }
 
     if (approvalType === 'CAPACITY_CHANGE') {

--- a/server/data/locationsApiClient.ts
+++ b/server/data/locationsApiClient.ts
@@ -373,7 +373,7 @@ export default class LocationsApiClient extends BaseApiClient {
         requestType: 'put',
       }),
       temporary: this.apiCall<
-        Location,
+        Location[],
         { locationId: string },
         {
           deactivationReason: string


### PR DESCRIPTION
## What

The change-request notification email for a temporary deactivation linked to:

```
/{prisonId}/cell-certificate/change-requests/undefined
```

so the link errored with `undefined` in place of the approval request ID. Reproducible by a cert reviewer deactivating a wing/landing and following the link in the resulting notification email.

## Why

This is **not** a race condition — the URL is built synchronously right after the API call returns.

The API endpoint `PUT /locations/{id}/deactivate/temporary` returns a **`List<LocationDTO>`** because deactivation cascades to the wing plus every sub-location. The frontend client typed this as a single `Location` and read `.pendingApprovalRequestId` straight off the array, which is always `undefined`. That value was then interpolated into the email URL.

The existing unit test masked the bug by mocking `deactivateTemporary` as a single object rather than the array the real API returns.

## Changes

- Type the `deactivate.temporary` client response as `Location[]` (the only other caller ignores the return value).
- In the `DEACTIVATION` branch of `submitApprovalRequest`, resolve the approval request id from the returned array — matching on the requested `locationId`, with a fallback to the first entry. All entries carry the same `pendingApprovalRequestId`.
- Update the unit test mock to the real array response shape so the regression is genuinely guarded.

## Verification

- `tsc --noEmit` and `eslint` clean
- `confirm.test.ts` passes (16/16)
- Sanity check: reverting only the array-unwrapping logic makes the DEACTIVATION test fail with `.../undefined`, confirming the test now catches the bug

No API repo changes required.