### PR TITLE
MAPA-134: Fix undefined id in email link for deactivations

### DIFF
--- a/integration_tests/mockApis/locationsApi.ts
+++ b/integration_tests/mockApis/locationsApi.ts
@@ -1290,7 +1290,7 @@ const stubLocationsDeactivateTemporary = () =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: {},
+      jsonBody: [{ pendingApprovalRequestId: 'pendingApprovalRequestId' }],
     },
   })
 

--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.test.ts
@@ -508,7 +508,7 @@ describe('Confirm', () => {
       updateCellSanitation: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'CELL_SANITATION-id' } as any),
       updateCellMark: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'CELL_MARK-id' } as any),
       requestReactivation: jest.fn().mockResolvedValue({ id: 'REACTIVATION-id' } as any),
-      deactivateTemporary: jest.fn().mockResolvedValue({ pendingApprovalRequestId: 'DEACTIVATION-id' } as any),
+      deactivateTemporary: jest.fn().mockResolvedValue([{ pendingApprovalRequestId: 'DEACTIVATION-id' }] as any),
     } as unknown as jest.Mocked<LocationsService>
     deepReq = {
       form: {

--- a/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
+++ b/server/commonTransactions/submitCertificationApprovalRequest/confirm.ts
@@ -578,7 +578,7 @@ export default class Confirm extends FormInitialStep {
           true,
           reasonForChange,
         )
-      ).pendingApprovalRequestId
+      )[0].pendingApprovalRequestId
     }
 
     if (approvalType === 'CAPACITY_CHANGE') {

--- a/server/data/locationsApiClient.ts
+++ b/server/data/locationsApiClient.ts
@@ -373,7 +373,7 @@ export default class LocationsApiClient extends BaseApiClient {
         requestType: 'put',
       }),
       temporary: this.apiCall<
-        Location,
+        Location[],
         { locationId: string },
         {
           deactivationReason: string


### PR DESCRIPTION
This pull request updates the handling of temporary deactivation requests in the locations API and its related services to consistently use arrays instead of single objects. This change ensures that the API and all consuming code treat the response for temporary deactivation as an array, improving consistency and preventing potential runtime errors.

**API Response and Type Consistency:**

* Changed the return type of the `temporary` method in `LocationsApiClient` from a single `Location` object to an array of `Location` objects, ensuring type consistency throughout the codebase.
* Updated the mock API response in `stubLocationsDeactivateTemporary` to return an array of objects instead of a single object, aligning with the new expected response format.

**Service and Test Adjustments:**

* Modified the `deactivateTemporary` mock implementation in `submitCertificationApprovalRequest/confirm.test.ts` to resolve to an array, matching the updated API contract.
* Updated the `Confirm` class in `submitCertificationApprovalRequest/confirm.ts` to extract the `pendingApprovalRequestId` from the first element of the returned array, rather than from a single object.