### PR TITLE
MAPA-135: Hide internal deactivation reasons

### DIFF
--- a/server/middleware/populateDeactivationReasonItems.test.ts
+++ b/server/middleware/populateDeactivationReasonItems.test.ts
@@ -128,4 +128,37 @@ describe('populateDeactivationReasonItems', () => {
       },
     })
   })
+
+  it('filters out reasons in the deny list', async () => {
+    deepReq.services = {
+      locationsService: {
+        getDeactivatedReasons: () =>
+          Promise.resolve({
+            TEST1: 'Test 1',
+            CONVERT_CELL_TO_ROOM: 'Convert cell to room',
+            NEW_BUILD: 'New build',
+            OTHER: 'Other',
+          }),
+      },
+    }
+
+    const callback = jest.fn()
+    await populateDeactivationReasonItems(deepReq as FormWizard.Request, deepRes as Response, callback)
+
+    const { items } = deepReq.form.options.fields.deactivationReason
+    expect(items).toEqual([
+      {
+        conditional: 'deactivationReasonDescription-TEST1',
+        text: 'Test 1',
+        value: 'TEST1',
+      },
+      {
+        conditional: 'deactivationReasonOther',
+        text: 'Other',
+        value: 'OTHER',
+      },
+    ])
+    expect(items.some(item => item.value === 'CONVERT_CELL_TO_ROOM')).toBe(false)
+    expect(items.some(item => item.value === 'NEW_BUILD')).toBe(false)
+  })
 })

--- a/server/middleware/populateDeactivationReasonItems.ts
+++ b/server/middleware/populateDeactivationReasonItems.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 
+const REASON_DENY_LIST = ['CONVERT_CELL_TO_ROOM', 'NEW_BUILD']
+
 export default async function populateDeactivationReasonItems(
   req: FormWizard.Request,
   _res: Response,
@@ -11,6 +13,7 @@ export default async function populateDeactivationReasonItems(
   const { deactivationReason } = req.form.options.fields
   const deactivationReasons = await locationsService.getDeactivatedReasons(systemToken)
   deactivationReason.items = Object.entries(deactivationReasons)
+    .filter(([key]) => !REASON_DENY_LIST.includes(key))
     .sort(([a, _], [b, __]) => {
       if ([a, b].includes('OTHER')) {
         return a === 'OTHER' ? 1 : -1


### PR DESCRIPTION
This pull request updates the `populateDeactivationReasonItems` middleware to filter out specific deactivation reasons using a deny list. It also adds a corresponding test to ensure these reasons are excluded as expected.

**Deactivation reason filtering:**

* Added a `REASON_DENY_LIST` constant in `populateDeactivationReasonItems.ts` to specify deactivation reasons that should be excluded (`CONVERT_CELL_TO_ROOM`, `NEW_BUILD`).
* Updated the logic in `populateDeactivationReasonItems` to filter out any reasons present in the deny list before populating the items.

**Testing:**

* Added a new test case to `populateDeactivationReasonItems.test.ts` to verify that reasons in the deny list are not included in the resulting items.