### PR TITLE
MAPA-122: Allow cells to be created on parents with existing cells

### DIFF
--- a/integration_tests/e2e/createCells/cellNumbers.cy.ts
+++ b/integration_tests/e2e/createCells/cellNumbers.cy.ts
@@ -34,6 +34,15 @@ context('Create landing - Create cells - Cell numbers', () => {
       Page.checkForError('create-cells_cellNumber1', 'Enter a cell number for cell 2')
     })
 
+    it('shows the correct error when a cell number is already in use by an existing cell', () => {
+      page.submit({
+        cellNumbers: ['9', '10', '2', '3'],
+      })
+
+      Page.checkForError('create-cells_cellNumber0', 'A cell with this number already exists')
+      Page.checkForError('create-cells_cellNumber1', 'A cell with this number already exists')
+    })
+
     it('shows the correct error when start numbering value is not a number', () => {
       page.startCreateCellInput().type('x')
       page.applyLink().click()

--- a/integration_tests/e2e/createCells/doorNumbers.cy.ts
+++ b/integration_tests/e2e/createCells/doorNumbers.cy.ts
@@ -34,6 +34,15 @@ context('Create landing - Create cells - Door numbers', () => {
       Page.checkForError('create-cells_doorNumber1', 'Enter a cell door number for A-2-101')
     })
 
+    it('shows the correct error when a door number is already in use by an existing cell', () => {
+      page.submit({
+        doorNumbers: ['A2-9', 'A2-10', '2', '3'],
+      })
+
+      Page.checkForError('create-cells_doorNumber0', 'A cell with this door number already exists')
+      Page.checkForError('create-cells_doorNumber1', 'A cell with this door number already exists')
+    })
+
     it('navigates to the next step when validation passes', () => {
       page.submit({
         doorNumbers: ['0', '1', '2', '3'],

--- a/integration_tests/e2e/createCells/setupStubs.ts
+++ b/integration_tests/e2e/createCells/setupStubs.ts
@@ -22,7 +22,26 @@ const existingLandingLocation = LocationFactory.build({
 const residentialSummary: LocationResidentialSummary = {
   parentLocation: existingLandingLocation,
   subLocationName: 'Cells',
-  subLocations: [],
+  subLocations: [
+    LocationFactory.build({
+      id: '7e570000-0000-1000-8000-000000000004',
+      pathHierarchy: 'A-2-009',
+      code: '009',
+      cellMark: 'A2-9',
+      parentId: existingLandingLocation.id,
+      locationType: 'CELL',
+      status: 'ACTIVE',
+    }),
+    LocationFactory.build({
+      id: '7e570000-0000-1000-8000-000000000005',
+      pathHierarchy: 'A-2-010',
+      code: '010',
+      cellMark: 'A2-10',
+      parentId: existingLandingLocation.id,
+      locationType: 'CELL',
+      status: 'LOCKED_DRAFT',
+    }),
+  ],
   topLevelLocationType: 'Wings',
   locationHierarchy: [],
   wingStructure: ['WING', 'LANDING', 'CELL'],

--- a/server/commonTransactions/createCells/cellDoorNumbers.ts
+++ b/server/commonTransactions/createCells/cellDoorNumbers.ts
@@ -63,27 +63,36 @@ export default class CellDoorNumbers extends BaseController {
   }
 
   override validateFields(req: FormWizard.Request, res: Response, callback: (errors: FormWizard.Errors) => void) {
-    const { values } = req.form
-    const cellsToCreate = req.sessionModel.get<number>('create-cells_cellsToCreate')
-
-    const validationErrors: FormWizard.Errors = {}
-
     super.validateFields(req, res, errors => {
+      const cellsToCreate = req.sessionModel.get<number>('create-cells_cellsToCreate')
+      const { values } = req.form
+      const { decoratedResidentialSummary } = res.locals
+      const validationErrors: FormWizard.Errors = {}
+
+      const existingDoorNumbers = Object.fromEntries(
+        decoratedResidentialSummary.subLocations.map(l => [l.cellMark, true]),
+      )
+      const newDoorNumbers: { [key: string]: number } = {}
+
       for (let i = 0; i < cellsToCreate; i += 1) {
         const fieldKey = `create-cells_doorNumber${i}`
-        const doorNumber = values[fieldKey]
+        const doorNumber = values[fieldKey] as string
 
-        if (doorNumber !== '' && !errors[fieldKey]) {
-          for (let oi = 0; oi < cellsToCreate; oi += 1) {
-            if (i !== oi) {
-              const otherDoorNumber = values[`create-cells_doorNumber${oi}`]
+        if (!newDoorNumbers[doorNumber]) {
+          newDoorNumbers[doorNumber] = 0
+        }
+        newDoorNumbers[doorNumber] += 1
+      }
 
-              if (doorNumber === otherDoorNumber) {
-                validationErrors[fieldKey] = this.formError(fieldKey, 'notUnique')
+      for (let i = 0; i < cellsToCreate; i += 1) {
+        const fieldKey = `create-cells_doorNumber${i}`
+        const doorNumber = values[fieldKey] as string
 
-                break
-              }
-            }
+        if (!errors[fieldKey]) {
+          if (existingDoorNumbers[doorNumber]) {
+            validationErrors[fieldKey] = this.formError(fieldKey, 'taken')
+          } else if (newDoorNumbers[doorNumber] > 1) {
+            validationErrors[fieldKey] = this.formError(fieldKey, 'notUnique')
           }
         }
       }

--- a/server/commonTransactions/createCells/cellDoorNumbers.ts
+++ b/server/commonTransactions/createCells/cellDoorNumbers.ts
@@ -3,11 +3,13 @@ import FormWizard from 'hmpo-form-wizard'
 import BaseController from './baseController'
 import capFirst from '../../formatters/capFirst'
 import getCellPath from './getCellPath'
+import populateExistingCells from './populateExistingCells'
 
 export default class CellDoorNumbers extends BaseController {
   override middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setupDynamicFields)
+    this.use(populateExistingCells)
   }
 
   setupDynamicFields(req: FormWizard.Request, res: Response, next: NextFunction) {
@@ -66,12 +68,10 @@ export default class CellDoorNumbers extends BaseController {
     super.validateFields(req, res, errors => {
       const cellsToCreate = req.sessionModel.get<number>('create-cells_cellsToCreate')
       const { values } = req.form
-      const { decoratedResidentialSummary } = res.locals
+      const { cells } = res.locals
       const validationErrors: FormWizard.Errors = {}
 
-      const existingDoorNumbers = Object.fromEntries(
-        decoratedResidentialSummary.subLocations.map(l => [l.cellMark, true]),
-      )
+      const existingDoorNumbers = Object.fromEntries(cells.map(l => [l.cellMark, true]))
       const newDoorNumbers: { [key: string]: number } = {}
 
       for (let i = 0; i < cellsToCreate; i += 1) {

--- a/server/commonTransactions/createCells/cellNumbers.ts
+++ b/server/commonTransactions/createCells/cellNumbers.ts
@@ -3,11 +3,13 @@ import FormWizard from 'hmpo-form-wizard'
 import BaseController from './baseController'
 import capFirst from '../../formatters/capFirst'
 import getCellPath from './getCellPath'
+import populateExistingCells from './populateExistingCells'
 
 export default class CellDoorNumbers extends BaseController {
   override middlewareSetup() {
     super.middlewareSetup()
     this.use(this.setupDynamicFields)
+    this.use(populateExistingCells)
   }
 
   setupDynamicFields(req: FormWizard.Request, res: Response, next: NextFunction) {
@@ -70,12 +72,10 @@ export default class CellDoorNumbers extends BaseController {
     super.validateFields(req, res, async errors => {
       const cellsToCreate = req.sessionModel.get<number>('create-cells_cellsToCreate')
       const { values } = req.form
-      const { decoratedResidentialSummary } = res.locals
+      const { cells } = res.locals
       const validationErrors: FormWizard.Errors = {}
 
-      const existingCodes = Object.fromEntries(
-        decoratedResidentialSummary.subLocations.map(l => [Number(l.code), true]),
-      )
+      const existingCodes = Object.fromEntries(cells.map(l => [Number(l.code), true]))
       const newCodes: { [key: number]: number } = {}
 
       for (let i = 0; i < cellsToCreate; i += 1) {

--- a/server/commonTransactions/createCells/cellNumbers.ts
+++ b/server/commonTransactions/createCells/cellNumbers.ts
@@ -70,26 +70,37 @@ export default class CellDoorNumbers extends BaseController {
     super.validateFields(req, res, async errors => {
       const cellsToCreate = req.sessionModel.get<number>('create-cells_cellsToCreate')
       const { values } = req.form
+      const { decoratedResidentialSummary } = res.locals
       const validationErrors: FormWizard.Errors = {}
+
+      const existingCodes = Object.fromEntries(
+        decoratedResidentialSummary.subLocations.map(l => [Number(l.code), true]),
+      )
+      const newCodes: { [key: number]: number } = {}
 
       for (let i = 0; i < cellsToCreate; i += 1) {
         const fieldKey = `create-cells_cellNumber${i}`
-        const cellNumber = values[fieldKey]
+        const code = Number(values[fieldKey])
 
-        if (cellNumber !== '' && !errors[fieldKey]) {
-          for (let oi = 0; oi < cellsToCreate; oi += 1) {
-            if (i !== oi) {
-              const otherCellNumber = values[`create-cells_cellNumber${oi}`]
+        if (!newCodes[code]) {
+          newCodes[code] = 0
+        }
+        newCodes[code] += 1
+      }
 
-              if (cellNumber === otherCellNumber) {
-                validationErrors[fieldKey] = this.formError(fieldKey, 'notUnique')
+      for (let i = 0; i < cellsToCreate; i += 1) {
+        const fieldKey = `create-cells_cellNumber${i}`
+        const code = Number(values[fieldKey])
 
-                break
-              }
-            }
+        if (!errors[fieldKey]) {
+          if (existingCodes[code]) {
+            validationErrors[fieldKey] = this.formError(fieldKey, 'taken')
+          } else if (newCodes[code] > 1) {
+            validationErrors[fieldKey] = this.formError(fieldKey, 'notUnique')
           }
         }
       }
+
       return callback({ ...errors, ...validationErrors })
     })
   }

--- a/server/commonTransactions/createCells/fields.ts
+++ b/server/commonTransactions/createCells/fields.ts
@@ -51,6 +51,7 @@ const fields: FormWizard.Fields = {
     name: 'cellNumber',
     errorMessages: {
       notUnique: 'Two cells have the same number',
+      taken: 'A cell with this number already exists',
     },
     classes: 'govuk-input--width-5',
     rows: 1,

--- a/server/commonTransactions/createCells/populateExistingCells.test.ts
+++ b/server/commonTransactions/createCells/populateExistingCells.test.ts
@@ -1,0 +1,46 @@
+import { DeepPartial } from 'fishery'
+import { Response, Request } from 'express'
+import buildDecoratedLocation from '../../testutils/buildDecoratedLocation'
+import populateExistingCells from './populateExistingCells'
+
+describe('populateExistingCells', () => {
+  let deepReq: DeepPartial<Request>
+  let deepRes: DeepPartial<Response>
+  let next: jest.Mock
+
+  beforeEach(() => {
+    next = jest.fn()
+    deepReq = {}
+    deepRes = {
+      locals: {
+        decoratedResidentialSummary: {
+          subLocationName: 'Cells',
+          subLocations: [
+            buildDecoratedLocation({ id: 'cell-1', status: 'ACTIVE' }),
+            buildDecoratedLocation({ id: 'cell-2', status: 'DRAFT' }),
+            buildDecoratedLocation({ id: 'cell-3', status: 'INACTIVE' }),
+          ],
+        },
+      },
+    }
+  })
+
+  it('sets cells to an empty array when the parent has no Cells sub-location', () => {
+    deepRes.locals.decoratedResidentialSummary.subLocationName = 'Landings'
+
+    populateExistingCells(deepReq as Request, deepRes as Response, next)
+
+    expect(deepRes.locals.cells).toEqual([])
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps subLocations and excludes DRAFT status locations', () => {
+    populateExistingCells(deepReq as Request, deepRes as Response, next)
+
+    expect(deepRes.locals.cells.map(cell => ({ id: cell.id, status: cell.status }))).toEqual([
+      { id: 'cell-1', status: 'ACTIVE' },
+      { id: 'cell-3', status: 'INACTIVE' },
+    ])
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/commonTransactions/createCells/populateExistingCells.ts
+++ b/server/commonTransactions/createCells/populateExistingCells.ts
@@ -1,0 +1,17 @@
+import middleware from '../../middleware/middleware'
+
+const populateExistingCells = middleware((req, res, next) => {
+  const { decoratedResidentialSummary } = res.locals
+
+  // The parent location can't have any cells, likely because the user is creating a new parent location with cells
+  if (decoratedResidentialSummary.subLocationName !== 'Cells') {
+    res.locals.cells = []
+  } else {
+    // DRAFT status locations are excluded, because they get included and modified in the edit-cells transaction
+    res.locals.cells = decoratedResidentialSummary.subLocations.map(l => l.raw).filter(l => l.status !== 'DRAFT')
+  }
+
+  next()
+})
+
+export default populateExistingCells

--- a/server/controllers/viewLocations/viewLocationsShow.ts
+++ b/server/controllers/viewLocations/viewLocationsShow.ts
@@ -24,10 +24,9 @@ export default async (req: Request, res: Response) => {
     }
   }
   if (!pendingApproval && req.canAccess('create_location')) {
-    if (!leafLevel && summary.subLocationName !== 'Cells') {
+    if (!leafLevel) {
       const singularizedLocationType = singularizeString(summary.subLocationName).toLowerCase()
-
-      locals.createButton = {
+      let createButton = {
         text: `Create new ${singularizedLocationType}`,
         href: `/create-new/${location.id}`,
         classes: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-3',
@@ -35,26 +34,20 @@ export default async (req: Request, res: Response) => {
           'data-qa': 'create-button',
         },
       }
-    } else if (summary.subLocationName === 'Cells') {
-      if (summary.subLocations.length === 0) {
-        locals.createButton = {
-          text: 'Create new cells',
-          href: `/create-cells/${location.id}`,
-          classes: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-3',
-          attributes: {
-            'data-qa': 'create-button',
-          },
-        }
-      } else if (location.status === 'DRAFT' && !summary.subLocations.find(l => l.status !== 'DRAFT')) {
-        locals.createButton = {
-          text: 'Edit cells',
-          href: `/edit-cells/${location.id}`,
-          classes: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-3',
-          attributes: {
-            'data-qa': 'create-button',
-          },
+
+      if (summary.subLocationName === 'Cells') {
+        if (summary.subLocations.find(l => l.status === 'DRAFT')) {
+          createButton = {
+            ...createButton,
+            text: 'Edit cells',
+            href: `/edit-cells/${location.id}`,
+          }
+        } else {
+          createButton = { ...createButton, text: 'Create new cells', href: `/create-cells/${location.id}` }
         }
       }
+
+      locals.createButton = createButton
     }
   }
 


### PR DESCRIPTION
This pull request enhances the validation logic for creating new cells and cell door numbers, ensuring that users cannot assign a number or door number that is already used by an existing cell. It introduces middleware to populate existing cells for validation, updates error messages, and improves related tests. The changes also refine the logic for displaying the "Create/Edit cells" button based on the current state of cells.

**Validation Improvements:**

* Added validation to prevent assigning a cell number or door number that is already used by an existing cell, displaying a specific error if a duplicate is detected. (`server/commonTransactions/createCells/cellNumbers.ts`, `server/commonTransactions/createCells/cellDoorNumbers.ts`, `server/commonTransactions/createCells/fields.ts`) [[1]](diffhunk://#diff-f696f0e39027afa08fd51b86f7ce07a2e74724e0b596f738a32dcd8f543d0310R75-R103) [[2]](diffhunk://#diff-111107a33490cc0541da24adfc99be1883e0d8759d9d9625e9f578f2e07693f3L66-R95) [[3]](diffhunk://#diff-205589aa24fd0f55c2947e93dfdd7fd80e95d53919cd25fb40c9103cc2406705R54)
* Introduced the `populateExistingCells` middleware to make existing cells available for validation and to exclude cells with `DRAFT` status from uniqueness checks. (`server/commonTransactions/createCells/populateExistingCells.ts`, `server/commonTransactions/createCells/cellNumbers.ts`, `server/commonTransactions/createCells/cellDoorNumbers.ts`) [[1]](diffhunk://#diff-ec8ffab04679f8a566fbccbfd801b96e91279ecbcad8f4194f4b80b3a144226dR1-R17) [[2]](diffhunk://#diff-f696f0e39027afa08fd51b86f7ce07a2e74724e0b596f738a32dcd8f543d0310R6-R12) [[3]](diffhunk://#diff-111107a33490cc0541da24adfc99be1883e0d8759d9d9625e9f578f2e07693f3R6-R12)

**Testing Enhancements:**

* Added and updated integration tests to verify error messages when attempting to use a cell number or door number that already exists. (`integration_tests/e2e/createCells/cellNumbers.cy.ts`, `integration_tests/e2e/createCells/doorNumbers.cy.ts`) [[1]](diffhunk://#diff-1f850b10cc3a921799d167d753146c74f3f736b353d04b839fee21a789024537R37-R45) [[2]](diffhunk://#diff-d8e060610dd5a6a1142adb1db676efeb2ca8bdbf58c4c8bb0b856a5a92e885dfR37-R45)
* Updated test stubs to include existing cells, ensuring that validation logic is properly exercised in tests. (`integration_tests/e2e/createCells/setupStubs.ts`)
* Added unit tests for the `populateExistingCells` middleware to ensure correct filtering of cells. (`server/commonTransactions/createCells/populateExistingCells.test.ts`)

**UI Logic Update:**

* Refined the logic for displaying the "Create/Edit cells" button: now shows "Edit cells" if any cell is in `DRAFT` status, and "Create new cells" otherwise. (`server/controllers/viewLocations/viewLocationsShow.ts`)