### PR TITLE
feat: approve/reject/withdraw special cell type requests

### DIFF
--- a/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/review.cy.ts
@@ -506,5 +506,156 @@ context('Cell Certificate - Change Requests - Review', () => {
         ])
       })
     })
+
+    context('When the approvalType is SPECIALIST_CELL_TYPE and we are adding a cell type', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'SPECIALIST_CELL_TYPE',
+            locationId: '7e570000-0000-1000-8000-000000000001',
+            locationKey: 'TST-A-1-001',
+            reasonForChange: 'Needed to change it',
+            specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+            currentSpecialistCellTypes: [],
+            locations: [
+              CertificateLocationFactory.build({
+                id: '7e570000-0000-1000-8000-000000000001',
+                locationType: 'CELL',
+                accommodationTypes: ['NORMAL_ACCOMMODATION'],
+                pathHierarchy: 'A-1-001',
+                certifiedNormalAccommodation: 0,
+                currentCertifiedNormalAccommodation: 1,
+                workingCapacity: 0,
+                currentWorkingCapacity: 1,
+                specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+                currentSpecialistCellTypes: [],
+              }),
+            ],
+          }),
+        )
+        LocationsApiStubber.stub.stubPrisonerLocationsId([{ cellLocation: 'A-1-001', prisoners: [] }])
+
+        CellCertificateChangeRequestsReviewPage.goTo('id1')
+        reviewPage = Page.verifyOnPage(CellCertificateChangeRequestsReviewPage)
+      })
+
+      it('Correctly displays the change request info and approve/reject options', () => {
+        cy.get('h1').should('contain', 'Review set special cell type request')
+
+        testGovukSummaryList('overview-list-SPECIALIST_CELL_TYPE', [
+          ['Location', 'A-1-001'],
+          ['Change type', 'Set special cell type'],
+          ['Explanation', 'Needed to change it'],
+          ['Submitted on', '3 October 2024'],
+          ['Submitted by', 'john smith'],
+        ])
+
+        testGovukTable('specialist-cell-type-table', [
+          ['A-1-001', '1 → 0', '1 → 0', 'None → Biohazard / dirty protest cell'],
+        ])
+
+        cy.get('input[name="approveOrReject"][type="radio"][value="APPROVE"]').should('exist')
+        cy.get('input[name="approveOrReject"][type="radio"][value="REJECT"]').should('exist')
+      })
+
+      it('Displays an error when no option is checked', () => {
+        reviewPage.submit({})
+        Page.checkForError('approveOrReject', 'Select if you want to approve or reject this change')
+      })
+
+      context('When approving the request would make the cell be overcrowded', () => {
+        beforeEach(() => {
+          LocationsApiStubber.stub.stubPrisonerLocationsId([
+            {
+              cellLocation: 'A-1-001',
+              prisoners: [PrisonerFactory.build(), PrisonerFactory.build(), PrisonerFactory.build()],
+            },
+          ])
+          LocationsApiStubber.stub.stubLocationsCertificationLocationApprove()
+        })
+
+        it('displays the too many occupants page on approve', () => {
+          reviewPage.submit({ approve: true })
+
+          Page.verifyOnPage(TooManyOccupantsPage)
+        })
+      })
+
+      // This tests changes to occupancy during the transaction
+      context('When the occupancy changes while approving', () => {
+        it('displays the too many occupants page when submitting the approve page', () => {
+          reviewPage.submit({ approve: true })
+
+          LocationsApiStubber.stub.stubPrisonerLocationsId([
+            {
+              cellLocation: 'A-1-001',
+              prisoners: [PrisonerFactory.build(), PrisonerFactory.build(), PrisonerFactory.build()],
+            },
+          ])
+          LocationsApiStubber.stub.stubLocationsCertificationLocationApprove()
+
+          Page.verifyOnPage(CellCertificateChangeRequestsApprovePage).submit({ confirm: true })
+
+          Page.verifyOnPage(TooManyOccupantsPage)
+        })
+      })
+    })
+
+    context('When the approvalType is SPECIALIST_CELL_TYPE and we are removing the cell type', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'SPECIALIST_CELL_TYPE',
+            locationId: '7e570000-0000-1000-8000-000000000001',
+            locationKey: 'TST-A-1-001',
+            reasonForChange: 'Needed to change it',
+            specialistCellTypes: [],
+            currentSpecialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+            locations: [
+              CertificateLocationFactory.build({
+                id: '7e570000-0000-1000-8000-000000000001',
+                locationType: 'CELL',
+                accommodationTypes: ['NORMAL_ACCOMMODATION'],
+                pathHierarchy: 'A-1-001',
+                certifiedNormalAccommodation: 0,
+                currentCertifiedNormalAccommodation: 1,
+                workingCapacity: 0,
+                currentWorkingCapacity: 1,
+                specialistCellTypes: [],
+                currentSpecialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+              }),
+            ],
+          }),
+        )
+        LocationsApiStubber.stub.stubPrisonerLocationsId([{ cellLocation: 'A-1-001', prisoners: [] }])
+
+        CellCertificateChangeRequestsReviewPage.goTo('id1')
+        reviewPage = Page.verifyOnPage(CellCertificateChangeRequestsReviewPage)
+      })
+
+      it('Correctly displays the change request info and approve/reject options', () => {
+        cy.get('h1').should('contain', 'Review remove special cell type request')
+
+        testGovukSummaryList('overview-list-SPECIALIST_CELL_TYPE', [
+          ['Location', 'A-1-001'],
+          ['Change type', 'Remove special cell type'],
+          ['Explanation', 'Needed to change it'],
+          ['Submitted on', '3 October 2024'],
+          ['Submitted by', 'john smith'],
+        ])
+
+        testGovukTable('specialist-cell-type-table', [
+          ['A-1-001', '1 → 0', '1 → 0', 'Biohazard / dirty protest cell → None'],
+        ])
+
+        cy.get('input[name="approveOrReject"][type="radio"][value="APPROVE"]').should('exist')
+        cy.get('input[name="approveOrReject"][type="radio"][value="REJECT"]').should('exist')
+      })
+
+      it('Displays an error when no option is checked', () => {
+        reviewPage.submit({})
+        Page.checkForError('approveOrReject', 'Select if you want to approve or reject this change')
+      })
+    })
   })
 })

--- a/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/show.cy.ts
@@ -357,6 +357,60 @@ context('Cell Certificate - Change Requests - Show', () => {
         ])
       })
     })
+
+    context('When the approvalType is SPECIALIST_CELL_TYPE', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsConstantsSpecialistCellType()
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'SPECIALIST_CELL_TYPE',
+            locationId: '7e570000-0000-1000-8000-000000000001',
+            locationKey: 'TST-A-1-001',
+            reasonForChange: 'Needed to change it',
+            certifiedNormalAccommodationChange: -1,
+            workingCapacityChange: -1,
+            maxCapacityChange: -1,
+            specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+            currentSpecialistCellTypes: [],
+            locations: [
+              CertificateLocationFactory.build({
+                id: '7e570000-0000-1000-8000-000000000001',
+                pathHierarchy: 'A-1-001',
+                certifiedNormalAccommodation: 0,
+                currentCertifiedNormalAccommodation: 1,
+                workingCapacity: 0,
+                currentWorkingCapacity: 1,
+                maxCapacity: 1,
+                currentMaxCapacity: 2,
+                specialistCellTypes: ['BIOHAZARD_DIRTY_PROTEST'],
+                currentSpecialistCellTypes: [],
+              }),
+            ],
+          }),
+        )
+
+        CellCertificateChangeRequestsShowPage.goTo('id1')
+        Page.verifyOnPage(CellCertificateChangeRequestsShowPage)
+      })
+
+      it('Correctly displays the change request info', () => {
+        cy.get('[data-qa="title-caption"]').should('contain', 'Cell A-1-001')
+        cy.get('h1').should('contain', 'Set special cell type request details')
+
+        testGovukSummaryList('overview-list-SPECIALIST_CELL_TYPE', [
+          ['Location', 'A-1-001'],
+          ['Change type', 'Set special cell type'],
+          ['Explanation', 'Needed to change it'],
+          ['Submitted on', '3 October 2024'],
+          ['Submitted by', 'john smith'],
+          ['Status', 'Awaiting review'],
+        ])
+
+        testGovukTable('specialist-cell-type-table', [
+          ['A-1-001', '1 → 0', '1 → 0', '2 → 1', 'None → Biohazard / dirty protest cell'],
+        ])
+      })
+    })
   })
 
   context('Review copy and withdraw button by status', () => {

--- a/integration_tests/e2e/cellCertificate/changeRequests/withdraw.cy.ts
+++ b/integration_tests/e2e/cellCertificate/changeRequests/withdraw.cy.ts
@@ -129,5 +129,35 @@ context('Cell Certificate - Change Requests - Withdraw', () => {
         )
       })
     })
+
+    context('When the approvalType is SPECIALIST_CELL_TYPE', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(
+          CertificationApprovalRequestFactory.build({
+            approvalType: 'SPECIALIST_CELL_TYPE',
+          }),
+        )
+        LocationsApiStubber.stub.stubLocationsCertificationLocationWithdraw()
+
+        CellCertificateChangeRequestsWithdrawPage.goTo('id1')
+        withdrawPage = Page.verifyOnPage(CellCertificateChangeRequestsWithdrawPage)
+      })
+
+      it('Displays an error when no explanation is entered', () => {
+        withdrawPage.submit({})
+        Page.checkForError('explanation', 'Explain why you are withdrawing this request')
+      })
+
+      it('Redirects to change requests and displays a banner', () => {
+        withdrawPage.submit({ explanation: 'Not good enough' })
+
+        Page.verifyOnPage(CellCertificateChangeRequestsIndexPage)
+        cy.get('#govuk-notification-banner-title').contains('Success')
+        cy.get('.govuk-notification-banner__content h3').contains('Change request withdrawn')
+        cy.get('.govuk-notification-banner__content p').contains(
+          'You have withdrawn the change request for cell A-1-001.',
+        )
+      })
+    })
   })
 })

--- a/integration_tests/e2e/cellCertificate/setupStubs.ts
+++ b/integration_tests/e2e/cellCertificate/setupStubs.ts
@@ -61,6 +61,8 @@ export default function setupStubs(roles = ['MANAGE_RES_LOCATIONS_OP_CAP']) {
     }),
   )
 
+  LocationsApiStubber.stub.stubPrisonerLocationsId([{ cellLocation: 'A-1-001', prisoners: [] }])
+
   LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison(approvalRequests)
   approvalRequests.forEach(requestApproval => {
     LocationsApiStubber.stub.stubLocationsCertificationRequestApprovals(requestApproval)

--- a/server/data/types/locationsApi/certificationApprovalRequest.d.ts
+++ b/server/data/types/locationsApi/certificationApprovalRequest.d.ts
@@ -44,6 +44,7 @@ export declare interface CertificationApprovalRequest {
   workingCapacity?: number
   certifiedNormalAccommodation?: number
   specialistCellTypes?: string[]
+  currentSpecialistCellTypes?: string[]
   currentConvertedCellType?: string
   convertedCellType?: string
   currentOtherConvertedCellType?: string

--- a/server/routes/cellCertificate/changeRequests/review/approvalCellWouldBeOvercrowded.test.ts
+++ b/server/routes/cellCertificate/changeRequests/review/approvalCellWouldBeOvercrowded.test.ts
@@ -17,7 +17,7 @@ describe('approvalCellWouldBeOvercrowded', () => {
       locals: {
         approvalRequest: {
           approvalType: 'CAPACITY_CHANGE',
-          locations: [{ workingCapacity: 2 }],
+          locations: [{ accommodationTypes: ['NORMAL_ACCOMMODATION'], locationType: 'CELL', workingCapacity: 2 }],
         },
         prisonerLocation: {
           prisoners: [{ prisonerNumber: 'A1234BC' }, { prisonerNumber: 'B5678DE' }, { prisonerNumber: 'C9012FG' }],
@@ -31,19 +31,36 @@ describe('approvalCellWouldBeOvercrowded', () => {
     expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 
-  it('returns false when approvalType is not CAPACITY_CHANGE', () => {
-    deepRes.locals.approvalRequest.approvalType = 'DRAFT'
-    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
-  })
-
   it('returns false when approvalRequest is absent', () => {
     deepRes.locals.approvalRequest = undefined
     expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 
-  it('returns true when occupants exceed proposed working capacity', () => {
+  it('returns true when NORMAL_ACCOMMODATION, CELL, and occupants exceed proposed working capacity', () => {
     // 3 prisoners, working capacity 2
     expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(true)
+  })
+
+  it('returns false when not NORMAL_ACCOMMODATION and occupants exceed proposed working capacity', () => {
+    deepRes.locals.approvalRequest.locations[0].accommodationTypes = ['CARE_AND_SEPARATION']
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
+  })
+
+  it('returns false when not a CELL and occupants exceed proposed working capacity', () => {
+    deepRes.locals.approvalRequest.locations[0].locationType = 'LANDING'
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
+  })
+
+  it('returns true when occupants exceed proposed max capacity', () => {
+    deepRes.locals.approvalRequest.locations[0].workingCapacity = undefined
+    deepRes.locals.approvalRequest.locations[0].maxCapacity = 0
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(true)
+  })
+
+  it('returns false when working capacity and max capacity are absent', () => {
+    deepRes.locals.approvalRequest.locations[0].maxCapacity = undefined
+    deepRes.locals.approvalRequest.locations[0].workingCapacity = undefined
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 
   it('returns false when occupants equal proposed working capacity', () => {
@@ -67,13 +84,34 @@ describe('approvalCellWouldBeOvercrowded', () => {
     expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 
-  it('returns false when there are no occupants', () => {
+  it('returns false when occupants equal proposed max capacity', () => {
+    deepRes.locals.approvalRequest.locations[0].workingCapacity = undefined
+    deepRes.locals.approvalRequest.locations[0].maxCapacity = 2
+    deepRes.locals.prisonerLocation.prisoners = [
+      { prisonerNumber: 'A1234BC' },
+      { prisonerNumber: 'B5678DE' },
+    ] as (typeof deepRes)['locals']['prisonerLocation']['prisoners']
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
+  })
+
+  it('returns false when occupants are below proposed max capacity', () => {
+    deepRes.locals.approvalRequest.locations[0].workingCapacity = undefined
+    deepRes.locals.approvalRequest.locations[0].maxCapacity = 2
+    deepRes.locals.prisonerLocation.prisoners = [
+      { prisonerNumber: 'A1234BC' },
+    ] as (typeof deepRes)['locals']['prisonerLocation']['prisoners']
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
+  })
+
+  it('returns false when there are no occupants and max capacity is 0', () => {
+    deepRes.locals.approvalRequest.locations[0].workingCapacity = undefined
+    deepRes.locals.approvalRequest.locations[0].maxCapacity = 0
     deepRes.locals.prisonerLocation = undefined
     expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 
-  it('treats missing locations as working capacity of 0 and returns true when there are occupants', () => {
-    deepRes.locals.approvalRequest.locations = undefined
-    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(true)
+  it('returns false when there are no occupants', () => {
+    deepRes.locals.prisonerLocation = undefined
+    expect(approvalCellWouldBeOvercrowded(deepReq as FormWizard.Request, deepRes as Response)).toBe(false)
   })
 })

--- a/server/routes/cellCertificate/changeRequests/review/approvalCellWouldBeOvercrowded.ts
+++ b/server/routes/cellCertificate/changeRequests/review/approvalCellWouldBeOvercrowded.ts
@@ -1,14 +1,29 @@
 import FormWizard from 'hmpo-form-wizard'
 import { Response } from 'express'
+import { isUndefined } from 'lodash'
 
 export default function approvalCellWouldBeOvercrowded(req: FormWizard.Request, res: Response) {
   if (req.sessionModel.get<string>('approveOrReject') !== 'APPROVE') return false
 
   const { approvalRequest, prisonerLocation } = res.locals
-  if (approvalRequest?.approvalType !== 'CAPACITY_CHANGE') return false
+  if (!approvalRequest) return false
 
   const occupants = prisonerLocation?.prisoners?.length || 0
-  const proposedWorkingCapacity = Number(approvalRequest.locations?.[0]?.workingCapacity) || 0
+  const proposedLocation = approvalRequest.locations?.[0]
+  if (!proposedLocation) return false
 
-  return occupants > proposedWorkingCapacity
+  const proposedMaxCapacity = proposedLocation.maxCapacity
+  if (!isUndefined(proposedMaxCapacity) && occupants > proposedMaxCapacity) return true
+
+  const proposedWorkingCapacity = proposedLocation.workingCapacity
+  if (
+    !isUndefined(proposedWorkingCapacity) &&
+    proposedLocation.locationType === 'CELL' &&
+    proposedLocation.accommodationTypes?.includes('NORMAL_ACCOMMODATION') &&
+    occupants > proposedWorkingCapacity
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/server/routes/cellCertificate/changeRequests/review/index.ts
+++ b/server/routes/cellCertificate/changeRequests/review/index.ts
@@ -1,5 +1,6 @@
 import express, { NextFunction, Request, Response } from 'express'
 import wizard from 'hmpo-form-wizard'
+import { isUndefined } from 'lodash'
 import steps from './steps'
 import fields from './fields'
 import protectRoute from '../../../../middleware/protectRoute'
@@ -7,7 +8,11 @@ import populateCertificationRequestDetails from '../../../../middleware/populate
 
 async function populatePrisonersForCapacityChange(req: Request, res: Response, next: NextFunction) {
   const { approvalRequest } = res.locals
-  if (approvalRequest?.approvalType === 'CAPACITY_CHANGE' && approvalRequest.locationId) {
+  const proposedLocation = approvalRequest.locations?.[0]
+  if (
+    (approvalRequest.locationId && !isUndefined(proposedLocation?.maxCapacity)) ||
+    !isUndefined(proposedLocation?.workingCapacity)
+  ) {
     const [prisonerLocation] = await req.services.locationsService.getPrisonersInLocation(
       req.session.systemToken,
       approvalRequest.locationId,


### PR DESCRIPTION
- Check occupancy when approving set special cell type request that affects capacity
- Add e2e tests for viewing/approving/withdrawing set/remove special cell type requests

[MAPA-66](https://dsdmoj.atlassian.net/browse/MAPA-66)
[MAPA-67](https://dsdmoj.atlassian.net/browse/MAPA-67)

[MAPA-66]: https://dsdmoj.atlassian.net/browse/MAPA-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAPA-67]: https://dsdmoj.atlassian.net/browse/MAPA-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ