### PR TITLE
MAPA-189: send allCertUsers emails to functional mailbox too

### DIFF
--- a/server/controllers/cellCertificate/changeRequests/review/approve.test.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/approve.test.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import { DeepPartial } from 'fishery'
 import ManageUsersService from '../../../../services/manageUsersService'
-import NotificationService, { notificationGroups, NotificationType } from '../../../../services/notificationService'
+import NotificationService, { NotificationType } from '../../../../services/notificationService'
 import LocationsService from '../../../../services/locationsService'
 import Approve from './approve'
 import * as notificationHelpers from '../../../../utils/notificationHelpers'
@@ -56,7 +56,7 @@ describe('Approve', () => {
     next = jest.fn()
 
     jest.clearAllMocks()
-    ;(notificationHelpers.getUserEmails as jest.Mock).mockResolvedValue([
+    ;(notificationHelpers.getAllCertUserEmails as jest.Mock).mockResolvedValue([
       'certificate_administrator@test.com',
       'certificate_reviewer@test.com',
       'certificate_viewer@test.com',
@@ -68,12 +68,7 @@ describe('Approve', () => {
     it('gets user emails for approved request notification group', async () => {
       await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
 
-      expect(notificationHelpers.getUserEmails).toHaveBeenCalledWith(
-        manageUsersService,
-        'token',
-        'MDI',
-        notificationGroups.allCertUsers,
-      )
+      expect(notificationHelpers.getAllCertUserEmails).toHaveBeenCalledWith(manageUsersService, 'token', 'MDI')
     })
 
     it('sends REQUEST_APPROVED notification to all cert users', async () => {

--- a/server/controllers/cellCertificate/changeRequests/review/approve.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/approve.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import FormInitialStep from '../../../base/formInitialStep'
-import { getUserEmails, sendNotification } from '../../../../utils/notificationHelpers'
-import { NotificationType, notificationGroups } from '../../../../services/notificationService'
+import { getAllCertUserEmails, sendNotification } from '../../../../utils/notificationHelpers'
+import { NotificationType } from '../../../../services/notificationService'
 import config from '../../../../config'
 import populateCertificationRequestDetails from '../../../../middleware/populateCertificationRequestDetails'
 import conditionallyPopulatePrisoners from './conditionallyPopulatePrisoners'
@@ -51,12 +51,7 @@ export default class Approve extends FormInitialStep {
     // Don't send emails in local dev (every deployed env counts as production)
     if (config.production || process.env.NODE_ENV === 'test') {
       // Send notifications to all cert roles
-      const emailAddresses = await getUserEmails(
-        manageUsersService,
-        systemToken,
-        prisonId,
-        notificationGroups.allCertUsers,
-      )
+      const emailAddresses = await getAllCertUserEmails(manageUsersService, systemToken, prisonId)
 
       await sendNotification(
         notifyService,

--- a/server/controllers/cellCertificate/changeRequests/review/reject.test.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/reject.test.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import { DeepPartial } from 'fishery'
 import ManageUsersService from '../../../../services/manageUsersService'
-import NotificationService, { notificationGroups, NotificationType } from '../../../../services/notificationService'
+import NotificationService, { NotificationType } from '../../../../services/notificationService'
 import LocationsService from '../../../../services/locationsService'
 import Reject from './reject'
 import * as notificationHelpers from '../../../../utils/notificationHelpers'
@@ -65,7 +65,7 @@ describe('Reject', () => {
     next = jest.fn()
 
     jest.clearAllMocks()
-    ;(notificationHelpers.getUserEmails as jest.Mock).mockResolvedValue([
+    ;(notificationHelpers.getAllCertUserEmails as jest.Mock).mockResolvedValue([
       'certificate_administrator@test.com',
       'certificate_requester@test.com',
       'certificate_viewer@test.com',
@@ -78,12 +78,7 @@ describe('Reject', () => {
     it('gets user emails for rejected request notification group', async () => {
       await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
 
-      expect(notificationHelpers.getUserEmails).toHaveBeenCalledWith(
-        manageUsersService,
-        'token',
-        'MDI',
-        notificationGroups.allCertUsers,
-      )
+      expect(notificationHelpers.getAllCertUserEmails).toHaveBeenCalledWith(manageUsersService, 'token', 'MDI')
     })
 
     it('sends REQUEST_REJECTED notification to all cert users', async () => {

--- a/server/controllers/cellCertificate/changeRequests/review/reject.ts
+++ b/server/controllers/cellCertificate/changeRequests/review/reject.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import FormInitialStep from '../../../base/formInitialStep'
-import { getUserEmails, sendNotification } from '../../../../utils/notificationHelpers'
-import { NotificationType, notificationGroups } from '../../../../services/notificationService'
+import { getAllCertUserEmails, sendNotification } from '../../../../utils/notificationHelpers'
+import { NotificationType } from '../../../../services/notificationService'
 import formatDateWithTime from '../../../../formatters/formatDateWithTime'
 import populateCertificationRequestDetails from '../../../../middleware/populateCertificationRequestDetails'
 import config from '../../../../config'
@@ -35,12 +35,7 @@ export default class Reject extends FormInitialStep {
     // Don't send emails in local dev (every deployed env counts as production)
     if (config.production || process.env.NODE_ENV === 'test') {
       // Send notifications to all cert roles
-      const emailAddresses = await getUserEmails(
-        manageUsersService,
-        systemToken,
-        prisonId,
-        notificationGroups.allCertUsers,
-      )
+      const emailAddresses = await getAllCertUserEmails(manageUsersService, systemToken, prisonId)
 
       await sendNotification(
         notifyService,

--- a/server/controllers/cellCertificate/changeRequests/withdraw.test.ts
+++ b/server/controllers/cellCertificate/changeRequests/withdraw.test.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import { DeepPartial } from 'fishery'
 import ManageUsersService from '../../../services/manageUsersService'
-import NotificationService, { notificationGroups, NotificationType } from '../../../services/notificationService'
+import NotificationService, { NotificationType } from '../../../services/notificationService'
 import LocationsService from '../../../services/locationsService'
 import Withdraw from './withdraw'
 import * as notificationHelpers from '../../../utils/notificationHelpers'
@@ -66,7 +66,7 @@ describe('Withdraw', () => {
     next = jest.fn()
 
     jest.clearAllMocks()
-    ;(notificationHelpers.getUserEmails as jest.Mock).mockResolvedValue([
+    ;(notificationHelpers.getAllCertUserEmails as jest.Mock).mockResolvedValue([
       'certificate_administrator@test.com',
       'certificate_reviewer@test.com',
       'certificate_viewer@test.com',
@@ -83,12 +83,7 @@ describe('Withdraw', () => {
     it('gets user emails for withdrawn request notification group', async () => {
       await controller.saveValues(deepReq as FormWizard.Request, deepRes as Response, next)
 
-      expect(notificationHelpers.getUserEmails).toHaveBeenCalledWith(
-        manageUsersService,
-        'token',
-        'MDI',
-        notificationGroups.allCertUsers,
-      )
+      expect(notificationHelpers.getAllCertUserEmails).toHaveBeenCalledWith(manageUsersService, 'token', 'MDI')
     })
 
     it('sends REQUEST_WITHDRAW notification to all cert users', async () => {

--- a/server/controllers/cellCertificate/changeRequests/withdraw.ts
+++ b/server/controllers/cellCertificate/changeRequests/withdraw.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Response } from 'express'
 import FormWizard from 'hmpo-form-wizard'
 import FormInitialStep from '../../base/formInitialStep'
-import { getUserEmails, sendNotification } from '../../../utils/notificationHelpers'
-import { NotificationType, notificationGroups } from '../../../services/notificationService'
+import { getAllCertUserEmails, sendNotification } from '../../../utils/notificationHelpers'
+import { NotificationType } from '../../../services/notificationService'
 import formatDateWithTime from '../../../formatters/formatDateWithTime'
 import populateCertificationRequestDetails from '../../../middleware/populateCertificationRequestDetails'
 import config from '../../../config'
@@ -32,12 +32,7 @@ export default class Withdraw extends FormInitialStep {
     // Don't send emails in local dev (every deployed env counts as production)
     if (config.production || process.env.NODE_ENV === 'test') {
       // Send notifications to all cert roles
-      const emailAddresses = await getUserEmails(
-        manageUsersService,
-        systemToken,
-        prisonId,
-        notificationGroups.allCertUsers,
-      )
+      const emailAddresses = await getAllCertUserEmails(manageUsersService, systemToken, prisonId)
 
       await sendNotification(
         notifyService,

--- a/server/utils/notificationHelpers.test.ts
+++ b/server/utils/notificationHelpers.test.ts
@@ -1,6 +1,8 @@
-import { getUserEmails } from './notificationHelpers'
+import { getUserEmails, getAllCertUserEmails } from './notificationHelpers'
 import ManageUsersService from '../services/manageUsersService'
 import ManageUsersApiClient from '../data/manageUsersApiClient'
+import config from '../config'
+import { notificationGroups } from '../services/notificationService'
 
 describe('getUserEmails', () => {
   const manageUsersService = new ManageUsersService(null) as jest.Mocked<ManageUsersService>
@@ -60,5 +62,56 @@ describe('getUserEmails', () => {
       expect(result).toEqual(['joe3@test.com'])
       expect(getUsersByCaseload).toHaveBeenCalled()
     })
+  })
+})
+
+describe('getAllCertUserEmails', () => {
+  const manageUsersService = new ManageUsersService(null) as jest.Mocked<ManageUsersService>
+  const originalFunctionalMailboxCertViewers = config.email.functionalMailboxCertViewers
+
+  beforeEach(() => {
+    config.email.functionalMailboxCertViewers = originalFunctionalMailboxCertViewers
+    manageUsersService.getAllUsersByActiveCaseload = jest
+      .fn()
+      .mockImplementation((_token: string, _prisonId: string, roles: string[]) =>
+        Promise.resolve({
+          content:
+            roles.length === 3
+              ? [
+                  { username: 'reviewer', email: 'reviewer@test.com' },
+                  { username: 'admin', email: 'admin@test.com' },
+                  { username: 'viewer', email: 'viewer@test.com' },
+                ]
+              : [
+                  { username: 'reviewer', email: 'reviewer@test.com' },
+                  { username: 'admin', email: 'admin@test.com' },
+                ],
+          totalPages: 1,
+        }),
+      )
+  })
+
+  it('combines non-viewer role emails and viewer role emails', async () => {
+    const result = await getAllCertUserEmails(manageUsersService, 'token', 'TST')
+
+    expect(manageUsersService.getAllUsersByActiveCaseload).toHaveBeenCalledWith(
+      'token',
+      'TST',
+      notificationGroups.allCertUsers,
+    )
+    expect(result).toEqual(['reviewer@test.com', 'admin@test.com', 'viewer@test.com'])
+  })
+
+  it('uses the functional mailbox instead of fetching viewer role emails when configured', async () => {
+    config.email.functionalMailboxCertViewers = 'functional-mailbox@test.com'
+
+    const result = await getAllCertUserEmails(manageUsersService, 'token', 'TST')
+
+    expect(manageUsersService.getAllUsersByActiveCaseload).toHaveBeenCalledTimes(1)
+    expect(manageUsersService.getAllUsersByActiveCaseload).toHaveBeenCalledWith('token', 'TST', [
+      'MANAGE_RES_LOCATIONS_OP_CAP',
+      'RESI__CERT_REVIEWER',
+    ])
+    expect(result).toEqual(['reviewer@test.com', 'admin@test.com', 'functional-mailbox@test.com'])
   })
 })

--- a/server/utils/notificationHelpers.ts
+++ b/server/utils/notificationHelpers.ts
@@ -1,6 +1,7 @@
 import { PaginatedUsers } from '../data/manageUsersApiClient'
-import { NotificationDetails, NotificationType } from '../services/notificationService'
+import { NotificationDetails, NotificationType, notificationGroups } from '../services/notificationService'
 import ManageUsersService from '../services/manageUsersService'
+import config from '../config'
 
 // Get distinct email addresses from manageUsersService, passing in caseload and roles.
 export async function getUserEmails(
@@ -14,6 +15,24 @@ export async function getUserEmails(
   const users: PaginatedUsers = await manageUsersService[getterFunction](systemToken, prisonId, roles)
   const emails = users.content.map(user => user.email).filter(email => email)
   return [...new Set(emails)]
+}
+
+// Get all cert user email addresses, using the functional mailbox for viewers if configured.
+export async function getAllCertUserEmails(
+  manageUsersService: ManageUsersService,
+  systemToken: string,
+  prisonId: string,
+): Promise<string[]> {
+  const certViewerMailbox = config.email.functionalMailboxCertViewers
+  if (!certViewerMailbox) {
+    return getUserEmails(manageUsersService, systemToken, prisonId, notificationGroups.allCertUsers)
+  }
+
+  const otherRoles = notificationGroups.allCertUsers.filter(
+    role => !notificationGroups.requestSubmittedUsers.includes(role),
+  )
+  const userEmailAddresses = await getUserEmails(manageUsersService, systemToken, prisonId, otherRoles)
+  return [...new Set([...userEmailAddresses, certViewerMailbox])]
 }
 
 export async function sendNotification(


### PR DESCRIPTION
When emailing all cert users, if the cert viewers functional mailbox is configured then we don't need to send the emails to individuals with that role, we just send it to the functional mailbox plus everybody else.