### PR TITLE
MAPA-92,MAPA-90: Add missing paragraph above locations table when archiving

### DIFF
--- a/server/views/macros/certificationApprovalRequest.njk
+++ b/server/views/macros/certificationApprovalRequest.njk
@@ -619,6 +619,8 @@
             <h2 class="govuk-heading-m">Proposed changes to the certificate</h2>
           {% endif %}
 
+          <p class="govuk-body">The following locations will be permanently removed from the cell certificate:</p>
+
           {% set locationTableRows = [] %}
           {% for location in request.locations %}
             {{ recurseArchiveLocationTable(locationTableRows, location, constants.specialistCellTypes) }}


### PR DESCRIPTION
Add missing paragraph above locations table when archiving a location.

[MAPA-90](https://dsdmoj.atlassian.net/browse/MAPA-90)
[MAPA-92](https://dsdmoj.atlassian.net/browse/MAPA-92)

[MAPA-90]: https://dsdmoj.atlassian.net/browse/MAPA-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAPA-92]: https://dsdmoj.atlassian.net/browse/MAPA-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ