### PR TITLE
MAPA-198: remove nonResi and archiveLocation feature flags

### DIFF
--- a/helm_deploy/hmpps-locations-inside-prison/values.yaml
+++ b/helm_deploy/hmpps-locations-inside-prison/values.yaml
@@ -65,8 +65,6 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: 'true'
     AUDIT_SQS_REGION: 'eu-west-2'
     AUDIT_SERVICE_NAME: 'UNASSIGNED' # Your audit service name
-    FLAG_NON_RESI: disabled
-    FLAG_ARCHIVE_LOCATION: disabled
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,8 +23,6 @@ generic-service:
     PRISON_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
-    FLAG_NON_RESI: enabled
-    FLAG_ARCHIVE_LOCATION: enabled
 
   allowlist:
     accessibility-audit: 5.181.59.114/32

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,5 +22,3 @@ generic-service:
     PRISON_API_URL: "https://prison-api-preprod.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: PRE-PRODUCTION
     AUDIT_ENABLED: "false"
-    FLAG_NON_RESI: enabled
-    FLAG_ARCHIVE_LOCATION: enabled

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,8 +19,6 @@ generic-service:
     LOCATIONS_API_URL: "https://locations-inside-prison-api.hmpps.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api.prison.service.justice.gov.uk"
     AUDIT_ENABLED: "false"
-    FLAG_NON_RESI: enabled
-    FLAG_ARCHIVE_LOCATION: enabled
 
 generic-prometheus-alerts:
   alertSeverity: move-a-prisoner-alerts-prod

--- a/helm_deploy/values-train.yaml
+++ b/helm_deploy/values-train.yaml
@@ -22,4 +22,3 @@ generic-service:
     ENVIRONMENT_NAME: Training
     AUDIT_ENABLED: "false"
     PRODUCTION_URL: "https://locations-inside-prison.hmpps.service.justice.gov.uk"
-    FLAG_ARCHIVE_LOCATION: enabled

--- a/integration_tests/e2e/archiveLocation/index.cy.ts
+++ b/integration_tests/e2e/archiveLocation/index.cy.ts
@@ -43,7 +43,6 @@ context('Archive location', () => {
       LocationsApiStubber.stub.stubLocations(location)
       LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
       LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-      cy.task('setFeatureFlag', { archiveLocation: true })
       cy.signIn()
     })
 
@@ -59,29 +58,6 @@ context('Archive location', () => {
       AuthStubber.stub.stubSignIn({ roles: ['MANAGE_RES_LOCATIONS_OP_CAP'] })
     })
 
-    context('when feature flag is disabled', () => {
-      beforeEach(() => {
-        location = LocationFactory.build({
-          active: false,
-          inactiveStatus: 'INACTIVE_TEMP',
-          locationType: 'CELL',
-        })
-        LocationsApiStubber.stub.stubLocationsLocationsResidentialSummary()
-        LocationsApiStubber.stub.stubLocationsLocationsResidentialSummaryForLocation({ parentLocation: location })
-        LocationsApiStubber.stub.stubLocations(location)
-        LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
-        LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: false })
-        cy.signIn()
-      })
-
-      it('does not show the archive button in the banner', () => {
-        ViewLocationsShowPage.goTo(location.prisonId, location.id)
-        const viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
-        viewLocationsShowPage.archiveCellButton().should('not.exist')
-      })
-    })
-
     context('when certification is disabled for the prison', () => {
       beforeEach(() => {
         location = LocationFactory.build({
@@ -94,7 +70,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
       })
 
@@ -117,7 +92,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
       })
 
@@ -140,7 +114,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
       })
 
@@ -165,7 +138,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
       })
 
@@ -190,7 +162,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
       })
 
@@ -227,7 +198,6 @@ context('Archive location', () => {
             },
           ],
         })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
 
         ViewLocationsShowPage.goTo(location.prisonId, location.id)
@@ -266,7 +236,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubLocations(location)
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
 
         ViewLocationsShowPage.goTo(location.prisonId, location.id)
@@ -308,7 +277,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
         LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
 
         ViewLocationsShowPage.goTo(location.prisonId, location.id)
@@ -370,7 +338,6 @@ context('Archive location', () => {
         LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
         LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
         LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
-        cy.task('setFeatureFlag', { archiveLocation: true })
         cy.signIn()
 
         ViewLocationsShowPage.goTo(location.prisonId, location.id)
@@ -458,7 +425,6 @@ context('Archive location', () => {
           LocationsApiStubber.stub.stubLocationsRequestPermanentDeactivation()
           LocationsApiStubber.stub.stubLocationsCertificationPrisonSignedOpCapChange()
           LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
-          cy.task('setFeatureFlag', { archiveLocation: true })
           cy.signIn()
 
           ViewLocationsShowPage.goTo(location.prisonId, location.id)
@@ -587,7 +553,6 @@ context('Archive location', () => {
           LocationsApiStubber.stub.stubLocationsRequestPermanentDeactivation()
           LocationsApiStubber.stub.stubLocationsCertificationPrisonSignedOpCapChange()
           LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
-          cy.task('setFeatureFlag', { archiveLocation: true })
           cy.signIn()
 
           ViewLocationsShowPage.goTo(location.prisonId, location.id)

--- a/server/config.ts
+++ b/server/config.ts
@@ -149,8 +149,5 @@ export default {
   productionUrl: get('PRODUCTION_URL', '#'),
   sandbox: environmentName === 'Training',
   feedbackFormUrl: get('FEEDBACK_FORM_URL', ''),
-  featureFlags: {
-    nonResi: get('FLAG_NON_RESI', 'disabled') === 'enabled',
-    archiveLocation: get('FLAG_ARCHIVE_LOCATION', 'disabled') === 'enabled',
-  },
+  featureFlags: {} as Record<string, boolean>,
 }

--- a/server/middleware/populateCards.ts
+++ b/server/middleware/populateCards.ts
@@ -115,7 +115,7 @@ export default function populateCards(locationsService: LocationsService) {
     }
 
     // Non-residential locations cards and permission message
-    if (req.featureFlags.nonResi && nonResiActive) {
+    if (nonResiActive) {
       // Check for non-resi specific roles (these are used by the non-resi app)
       const hasEditRole = userRoles.includes('NONRESI__MAINTAIN_LOCATION')
 
@@ -139,12 +139,9 @@ export default function populateCards(locationsService: LocationsService) {
             },
       ]
       res.locals.nonResiPermissionMessage = null
-    } else if (req.featureFlags.nonResi) {
-      res.locals.nonResiCards = null
-      res.locals.nonResiPermissionMessage = 'You do not have permission to view non-residential locations.'
     } else {
       res.locals.nonResiCards = null
-      res.locals.nonResiPermissionMessage = null
+      res.locals.nonResiPermissionMessage = 'You do not have permission to view non-residential locations.'
     }
 
     next()

--- a/server/middleware/setCanAccess.ts
+++ b/server/middleware/setCanAccess.ts
@@ -31,10 +31,6 @@ export default function setCanAccess(locationService: LocationsService) {
       }
     }
 
-    if (req.featureFlags.archiveLocation === false) {
-      permissionOverrides.archive_location = false
-    }
-
     req.canAccess = permission => {
       if (permission in permissionOverrides) {
         const override = permissionOverrides[permission]

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -70,10 +70,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
   app.use((req, res, next) => {
-    req.featureFlags = {
-      nonResi: false,
-      archiveLocation: false,
-    }
+    req.featureFlags = {}
     next()
   })
   app.use(setCanAccess(services.locationsService))


### PR DESCRIPTION
Archive location can stay enabled permanently now, and non-resi is controlled by per-prison config.