### PR TITLE
MAPA-155: Remove actions from h1 but keep tags (accessibility fix)

### DIFF
--- a/server/views/pages/viewLocations/show.njk
+++ b/server/views/pages/viewLocations/show.njk
@@ -21,17 +21,19 @@
   <span class="govuk-caption-m" data-qa="location-type">{{ locationType }}</span>
   <div class="header-row">
     <div class="header-left">
-    <h1 class="govuk-heading-l">{{ locationName }}</h1>
-      {% if decoratedResidentialSummary.location.leafLevel and decoratedResidentialSummary.location.certifiedCell %}
-        {{ govukTag({
-          text: 'Certified',
-          classes: "govuk-tag--hollow",
-          attributes: {
-            "data-qa": "certified-tag"
-          }
-        }) }}
-      {% endif %}
-      {{ locationStatusTag(decoratedResidentialSummary.location) }}
+      <h1 class="govuk-heading-l">
+        {{ locationName }}
+        {% if decoratedResidentialSummary.location.leafLevel and decoratedResidentialSummary.location.certifiedCell %}
+          {{ govukTag({
+            text: 'Certified',
+            classes: "govuk-tag--hollow",
+            attributes: {
+              "data-qa": "certified-tag"
+            }
+          }) }}
+        {% endif %}
+        {{ locationStatusTag(decoratedResidentialSummary.location) }}
+      </h1>
     </div>
 
     {% if actions | length %}


### PR DESCRIPTION
I had already fixed the main issue in the report by removing the action buttons from the h1 element, but the report suggests to keep the tags inside the h1 so I have put them back in there. It didn't affect the styling.