### PR TITLE
MAPA-212: Forbid reactivate/deactivate when child locations pending

### DIFF
--- a/integration_tests/e2e/deactivate/certificationFlow/cell/setupStubs.ts
+++ b/integration_tests/e2e/deactivate/certificationFlow/cell/setupStubs.ts
@@ -45,5 +45,6 @@ export function setupStubs(role: string, stubLocation = location) {
   LocationsApiStubber.stub.stubPrisonerLocationsId([])
   LocationsApiStubber.stub.stubLocationsDeactivateTemporary()
   LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+  LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
 }

--- a/integration_tests/e2e/deactivate/certificationFlow/cell/temporaryToCertified/setupStubs.ts
+++ b/integration_tests/e2e/deactivate/certificationFlow/cell/temporaryToCertified/setupStubs.ts
@@ -46,5 +46,6 @@ export function setupStubs(role: string, stubLocation = location) {
   LocationsApiStubber.stub.stubPrisonerLocationsId([])
   LocationsApiStubber.stub.stubLocationsDeactivateTemporary()
   LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+  LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
 }

--- a/integration_tests/e2e/deactivate/certificationFlow/wing/setupStubs.ts
+++ b/integration_tests/e2e/deactivate/certificationFlow/wing/setupStubs.ts
@@ -49,5 +49,6 @@ export function setupStubs(role: string) {
   LocationsApiStubber.stub.stubLocationsDeactivateTemporary()
   LocationsApiStubber.stub.stubLocationsCertificationPrisonSignedOpCapChange()
   LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+  LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
 }

--- a/integration_tests/e2e/deactivate/permanent.cy.ts
+++ b/integration_tests/e2e/deactivate/permanent.cy.ts
@@ -51,6 +51,7 @@ context('Deactivate permanent', () => {
     })
     LocationsApiStubber.stub.stubLocations(location)
     LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
+    LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   })
 
   context('without the MANAGE_RES_LOCATIONS_OP_CAP role', () => {

--- a/integration_tests/e2e/deactivate/temporary.cy.ts
+++ b/integration_tests/e2e/deactivate/temporary.cy.ts
@@ -9,6 +9,9 @@ import ManageUsersApiStubber from '../../mockApis/manageUsersApi'
 import LocationsApiStubber from '../../mockApis/locationsApi'
 import PrisonResidentialSummaryFactory from '../../../server/testutils/factories/prisonResidentialSummary'
 import AuthStubber from '../../mockApis/auth'
+import RequestsPendingPage from '../../pages/requestsPending'
+import ViewLocationsIndexPage from '../../pages/viewLocations'
+import CellCertificateChangeRequestsIndexPage from '../../pages/cellCertificate/changeRequests'
 
 context('Deactivate temporary', () => {
   const location = LocationFactory.build({
@@ -45,6 +48,7 @@ context('Deactivate temporary', () => {
       }),
     )
     LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
+    LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   })
 
   context('without any roles', () => {
@@ -129,6 +133,51 @@ context('Deactivate temporary', () => {
         Page.verifyOnPage(ViewLocationsShowPage)
       })
     }
+
+    describe('requests pending page', () => {
+      beforeEach(() => {
+        LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+        LocationsApiStubber.stub.stubPendingApprovalsBelow({
+          hasPendingBelow: true,
+          pendingLocations: [
+            {
+              id: '6bcfab2c-df86-467b-89ca-e1eb1bb84249',
+              key: 'LEI-A-1-016',
+              locationType: 'CELL',
+              parentId: 'd8ddb0a7-1e39-425c-a32f-d128e80ca05b',
+              parentKey: 'LEI-A-1',
+              parentLocationType: 'LANDING',
+            },
+          ],
+        })
+
+        ViewLocationsShowPage.goTo(location.prisonId, location.id)
+        const viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
+        viewLocationsShowPage.actionsMenu().click()
+        viewLocationsShowPage.deactivateAction().click()
+      })
+
+      it('has a back link to the view location page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.backLink().click()
+
+        Page.verifyOnPage(ViewLocationsIndexPage)
+      })
+
+      it('has a cancel link that leads to the view location page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.returnLink().click()
+
+        Page.verifyOnPage(ViewLocationsIndexPage)
+      })
+
+      it('has a link to the cert approvals page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.certApprovalsLink().click()
+
+        Page.verifyOnPage(CellCertificateChangeRequestsIndexPage)
+      })
+    })
 
     context('when the cell is occupied', () => {
       beforeEach(() => {

--- a/integration_tests/e2e/reactivate/location/setupStubs.ts
+++ b/integration_tests/e2e/reactivate/location/setupStubs.ts
@@ -41,5 +41,6 @@ export default function setupStubs(role: string, location: Location) {
   LocationsApiStubber.stub.stubLocationsBulkReactivate()
   LocationsApiStubber.stub.stubLocationsCertificationLocationReactivationRequestApproval()
   LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+  LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
   LocationsApiStubber.stub.stubLocationsCertificationRequestApprovalsPrison([])
 }

--- a/integration_tests/e2e/reactivate/parent/index.cy.ts
+++ b/integration_tests/e2e/reactivate/parent/index.cy.ts
@@ -7,6 +7,9 @@ import ReactivateParentConfirmPage from '../../../pages/reactivate/parent/confir
 import ReactivateParentSelectPage from '../../../pages/reactivate/parent/select'
 import ViewLocationsShowPage from '../../../pages/viewLocations/show'
 import ManageUsersApiStubber from '../../../mockApis/manageUsersApi'
+import RequestsPendingPage from '../../../pages/requestsPending'
+import ViewLocationsIndexPage from '../../../pages/viewLocations'
+import CellCertificateChangeRequestsIndexPage from '../../../pages/cellCertificate/changeRequests'
 
 const createLanding = (id: number) => {
   return LocationFactory.build({
@@ -205,6 +208,7 @@ context('Reactivate parent', () => {
         }),
       )
       cy.task('stubGetPrisonConfiguration', { prisonId: 'TST', certificationActive: 'INACTIVE' })
+      cy.task('stubPendingApprovalsBelow', { hasPendingBelow: false, pendingLocations: [] })
       cy.signIn()
       ViewLocationsShowPage.goTo(inactiveWing.prisonId, inactiveWing.id)
       viewLocationsShowPage = Page.verifyOnPage(ViewLocationsShowPage)
@@ -213,6 +217,44 @@ context('Reactivate parent', () => {
     it('shows the reactivate buttons in the inactive location banner', () => {
       viewLocationsShowPage.inactiveBannerActivateEntireButton().should('exist')
       viewLocationsShowPage.inactiveBannerActivateIndividualButton().should('exist')
+    })
+
+    describe('requests pending page', () => {
+      beforeEach(() => {
+        cy.task('stubPendingApprovalsBelow', {
+          hasPendingBelow: true,
+          pendingLocations: [
+            {
+              id: '6bcfab2c-df86-467b-89ca-e1eb1bb84249',
+              key: 'LEI-A-1-016',
+              locationType: 'CELL',
+              parentId: 'd8ddb0a7-1e39-425c-a32f-d128e80ca05b',
+              parentKey: 'LEI-A-1',
+              parentLocationType: 'LANDING',
+            },
+          ],
+        })
+
+        viewLocationsShowPage.inactiveBannerActivateEntireButton().click()
+      })
+
+      it('has a back link to the view location page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.backLink().click()
+        Page.verifyOnPage(ViewLocationsIndexPage)
+      })
+
+      it('has a cancel link that leads to the view location page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.returnLink().click()
+        Page.verifyOnPage(ViewLocationsIndexPage)
+      })
+
+      it('has a link to the cert approvals page', () => {
+        const requestsPendingPage = Page.verifyOnPage(RequestsPendingPage)
+        requestsPendingPage.certApprovalsLink().click()
+        Page.verifyOnPage(CellCertificateChangeRequestsIndexPage)
+      })
     })
 
     context('after clicking "Activate entire"', () => {

--- a/integration_tests/e2e/reactivate/parent/singleCell.cy.ts
+++ b/integration_tests/e2e/reactivate/parent/singleCell.cy.ts
@@ -95,6 +95,7 @@ context('Reactivate cell (from reactivate parent)', () => {
         subLocations: [inactiveCell1, inactiveCell2, inactiveCell3],
       })
       LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
+      LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
       cy.signIn()
     })
 
@@ -125,6 +126,7 @@ context('Reactivate cell (from reactivate parent)', () => {
       LocationsApiStubber.stub.stubLocationsConstantsSpecialistCellType()
       LocationsApiStubber.stub.stubLocationsConstantsUsedForType()
       LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'INACTIVE' })
+      LocationsApiStubber.stub.stubPendingApprovalsBelow({ hasPendingBelow: false, pendingLocations: [] })
       LocationsApiStubber.stub.stubLocationsBulkReactivate()
       LocationsApiStubber.stub.stubLocationsLocationsResidentialSummary(residentialSummary)
       locations.forEach(location => {

--- a/server/commonTransactions/requestsPending/index.ts
+++ b/server/commonTransactions/requestsPending/index.ts
@@ -1,0 +1,9 @@
+import steps from './steps'
+
+class RequestsPending {
+  getSteps() {
+    return steps
+  }
+}
+
+export default new RequestsPending()

--- a/server/commonTransactions/requestsPending/steps.ts
+++ b/server/commonTransactions/requestsPending/steps.ts
@@ -1,0 +1,16 @@
+import FormWizard from 'hmpo-form-wizard'
+import RequestsPending from '../../controllers/requestsPending'
+import paths from '../../utils/paths'
+
+const steps: FormWizard.Steps = {
+  '/requests-pending': {
+    backLink: (_req, res) => paths.location.view(res.locals.decoratedLocation),
+    checkJourney: false,
+    controller: RequestsPending,
+    pageTitle: 'You can’t request a change to the certificate for this location currently',
+    templatePath: 'pages/requestsPending',
+    template: 'index',
+  },
+}
+
+export default steps

--- a/server/routes/archiveLocation/steps.ts
+++ b/server/routes/archiveLocation/steps.ts
@@ -1,7 +1,7 @@
 import FormWizard from 'hmpo-form-wizard'
 import { Response } from 'express'
 import CertChangeDisclaimer from '../../commonTransactions/certChangeDisclaimer'
-import RequestsPending from '../../controllers/requestsPending'
+import RequestsPending from '../../commonTransactions/requestsPending'
 import FormStep from '../../controllers/base/formStep'
 import UpdateSignedOpCap from '../../commonTransactions/updateSignedOpCap'
 import SubmitCertificationApprovalRequest from '../../commonTransactions/submitCertificationApprovalRequest'
@@ -21,14 +21,7 @@ const steps: FormWizard.Steps = {
     backLink: locationPage,
     next: [{ fn: hasPendingApprovalsBelow, next: 'requests-pending' }, 'cert-change-disclaimer'],
   },
-  '/requests-pending': {
-    backLink: locationPage,
-    checkJourney: false,
-    controller: RequestsPending,
-    pageTitle: 'You can’t request a change to the certificate for this location currently',
-    templatePath: 'pages/requestsPending',
-    template: 'index',
-  },
+  ...RequestsPending.getSteps(),
   ...CertChangeDisclaimer.getSteps({
     next: 'reason',
     title: (_req, _res) => 'Archiving a location',

--- a/server/routes/deactivate/index.ts
+++ b/server/routes/deactivate/index.ts
@@ -7,6 +7,7 @@ import protectRoute from '../../middleware/protectRoute'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import populatePrisonersInLocation from '../../middleware/populatePrisonersInLocation'
 import populateTitleCaptionFromLocationOrPrison from '../../middleware/populateTitleCaptionFromLocationOrPrison'
+import getPendingApprovalsBelow from '../../middleware/getPendingApprovalsBelow'
 
 const router = express.Router({ mergeParams: true })
 
@@ -24,6 +25,7 @@ router.use(
   populateLocation({ decorate: true, includeCurrentCertificate: true }),
   populateTitleCaptionFromLocationOrPrison,
   populatePrisonersInLocation(),
+  getPendingApprovalsBelow,
   checkSupportedLocationType,
   wizard(steps, fields, {
     name: 'deactivate',

--- a/server/routes/deactivate/steps.ts
+++ b/server/routes/deactivate/steps.ts
@@ -11,6 +11,7 @@ import TemporaryInactiveInit from '../../controllers/deactivate/temporaryInactiv
 import paths from '../../utils/paths'
 import FormStep from '../../controllers/base/formStep'
 import DeactivatePermanentBase from '../../controllers/deactivate/permanent/base'
+import RequestsPending from '../../commonTransactions/requestsPending'
 
 function isCellOccupied(_req: FormWizard.Request, res: Response) {
   return res.locals.prisonerLocation?.prisoners?.length > 0
@@ -51,6 +52,9 @@ function permanentDeactivationForbidden(req: FormWizard.Request, _res: Response)
   return !req.canAccess('deactivate:permanent')
 }
 
+const hasPendingApprovalsBelow = (_req: FormWizard.Request, res: Response) =>
+  res.locals.pendingApprovalsBelow.hasPendingBelow
+
 const steps: FormWizard.Steps = {
   '/': {
     entryPoint: true,
@@ -59,6 +63,7 @@ const steps: FormWizard.Steps = {
     skip: true,
     backLink: (_req, res) => paths.location.view(res.locals.decoratedLocation),
     next: [
+      { fn: hasPendingApprovalsBelow, next: 'requests-pending' },
       { fn: isCellOccupied, next: 'occupied' },
       {
         fn: (_req, res) =>
@@ -77,6 +82,7 @@ const steps: FormWizard.Steps = {
       'type',
     ],
   },
+  ...RequestsPending.getSteps(),
   '/cell-cert-change': {
     fields: ['reduceWorkingCapacity'],
     next: [{ field: 'reduceWorkingCapacity', value: 'YES', next: 'cert-change-disclaimer' }, 'temporary/details'],

--- a/server/routes/reactivate/location/index.ts
+++ b/server/routes/reactivate/location/index.ts
@@ -6,6 +6,7 @@ import populateLocation from '../../../middleware/populateLocation'
 import protectRoute from '../../../middleware/protectRoute'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import populateTitleCaptionFromLocationOrPrison from '../../../middleware/populateTitleCaptionFromLocationOrPrison'
+import getPendingApprovalsBelow from '../../../middleware/getPendingApprovalsBelow'
 
 const router = express.Router({ mergeParams: true })
 
@@ -22,6 +23,7 @@ router.use(
   protectRoute('reactivate'),
   populateLocation({ decorate: true, includeCurrentCertificate: true }),
   populateTitleCaptionFromLocationOrPrison,
+  getPendingApprovalsBelow,
   checkIsInactive,
   wizard(steps, fields, {
     name: 'reactivate',

--- a/server/routes/reactivate/location/steps.ts
+++ b/server/routes/reactivate/location/steps.ts
@@ -15,6 +15,7 @@ import SubmitCertificationApprovalRequest from '../../../commonTransactions/subm
 import NoCertChangeConfirm from '../../../controllers/reactivate/location/noCertChangeConfirm'
 import hasAnyCertCapacityChange from '../../../controllers/reactivate/location/util/hasAnyCertCapacityChange'
 import paths from '../../../utils/paths'
+import RequestsPending from '../../../commonTransactions/requestsPending'
 
 export function isTemporaryDeactivation(_req: FormWizard.Request, res: Response) {
   const { prisonConfiguration, decoratedLocation } = res.locals
@@ -24,6 +25,9 @@ export function isTemporaryDeactivation(_req: FormWizard.Request, res: Response)
 
   return decoratedLocation.inactiveStatus !== 'INACTIVE_MATCHING_CELL_CERT'
 }
+
+const hasPendingApprovalsBelow = (_req: FormWizard.Request, res: Response) =>
+  res.locals.pendingApprovalsBelow.hasPendingBelow
 
 function wrapSetCellTypeController(path: string, step: FormWizard.Step) {
   if (path === '/:cellId/set-cell-type/init') {
@@ -190,6 +194,10 @@ const steps: FormWizard.Steps = {
     backLink: (_req, res) => paths.location.view(res.locals.decoratedLocation),
     next: [
       {
+        fn: hasPendingApprovalsBelow,
+        next: 'requests-pending',
+      },
+      {
         fn: isTemporaryDeactivation,
         next: 'no-cert-change-confirm',
       },
@@ -197,6 +205,7 @@ const steps: FormWizard.Steps = {
     ],
     controller: ReactivateLocationInit,
   },
+  ...RequestsPending.getSteps(),
   '/check-capacity': {
     next: [{ fn: hasAnyCertCapacityChange, next: 'cert-change-disclaimer' }, 'no-cert-change-confirm'],
     fields: ['baselineCna', 'workingCapacity'],

--- a/server/routes/reactivate/parent/index.ts
+++ b/server/routes/reactivate/parent/index.ts
@@ -5,6 +5,7 @@ import fields from './fields'
 import protectRoute from '../../../middleware/protectRoute'
 import populateLocation from '../../../middleware/populateLocation'
 import populateTitleCaptionFromLocationOrPrison from '../../../middleware/populateTitleCaptionFromLocationOrPrison'
+import getPendingApprovalsBelow from '../../../middleware/getPendingApprovalsBelow'
 
 const router = express.Router({ mergeParams: true })
 
@@ -12,6 +13,7 @@ router.use(
   protectRoute('reactivate'),
   populateLocation({ decorate: true }),
   populateTitleCaptionFromLocationOrPrison,
+  getPendingApprovalsBelow,
   wizard(steps, fields, {
     name: 'reactivate-parent',
     templatePath: 'pages/reactivate/parent',

--- a/server/routes/reactivate/parent/steps.ts
+++ b/server/routes/reactivate/parent/steps.ts
@@ -1,13 +1,18 @@
 import FormWizard from 'hmpo-form-wizard'
+import { Response } from 'express'
 import ReactivateParentSelect from '../../../controllers/reactivate/parent/select'
 import ReactivateParentCheckCapacity from '../../../controllers/reactivate/parent/checkCapacity'
 import ReactivateParentConfirm from '../../../controllers/reactivate/parent/confirm'
 import ReactivateParentChangeCapacity from '../../../controllers/reactivate/parent/changeCapacity'
 import paths from '../../../utils/paths'
+import RequestsPending from '../../../commonTransactions/requestsPending'
 
 const isSelect = (req: FormWizard.Request) => {
   return !!req.query.select
 }
+
+const hasPendingApprovalsBelow = (_req: FormWizard.Request, res: Response) =>
+  res.locals.pendingApprovalsBelow.hasPendingBelow
 
 const steps: FormWizard.Steps = {
   '/': {
@@ -15,9 +20,14 @@ const steps: FormWizard.Steps = {
     reset: true,
     resetJourney: true,
     skip: true,
-    next: [{ fn: isSelect, next: 'select' }, 'check-capacity'],
+    next: [
+      { fn: hasPendingApprovalsBelow, next: 'requests-pending' },
+      { fn: isSelect, next: 'select' },
+      'check-capacity',
+    ],
     backLink: (_req, res) => paths.location.view(res.locals.decoratedLocation),
   },
+  ...RequestsPending.getSteps(),
   '/select': {
     controller: ReactivateParentSelect,
     fields: ['selectLocations'],


### PR DESCRIPTION
Forbid reactivate/deactivate parent location when child locations have pending requests.

[MAPA-212](https://dsdmoj.atlassian.net/browse/MAPA-212)

[MAPA-212]: https://dsdmoj.atlassian.net/browse/MAPA-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ