### PR TITLE
MAPA-261: Change manage locations tile content if cert disabled

### DIFF
--- a/server/middleware/populateCards.ts
+++ b/server/middleware/populateCards.ts
@@ -20,13 +20,15 @@ export default middleware((req, res, next) => {
   const hasResiRole = userRoles.some(role => RESI_ROLES.includes(role))
   const showResiCards = resiActive && hasResiRole
 
+  const manageResiDescription = `View and update information about existing locations${certificationEnabled ? ' or create new residential locations' : ''}.`
+
   res.locals.resiCards = [
     {
       clickable: true,
       visible: showResiCards,
       heading: `Manage residential locations`,
       href: paths.location.view(prisonId),
-      description: 'View and update information about existing locations or create new residential locations.',
+      description: manageResiDescription,
       'data-qa': 'view-locations-card',
     },
     {


### PR DESCRIPTION
Show different manage locations tile content depending on whether the prison is cert enabled or not.

[MAPA-261](https://dsdmoj.atlassian.net/browse/MAPA-261)

[MAPA-261]: https://dsdmoj.atlassian.net/browse/MAPA-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ