### PR TITLE
MAPA-320: Skip to confirm page when caps match current cert

### DIFF
--- a/integration_tests/e2e/changeCellCapacity/index.cy.ts
+++ b/integration_tests/e2e/changeCellCapacity/index.cy.ts
@@ -476,5 +476,62 @@ context('Change cell capacity', () => {
         cy.get('.govuk-notification-banner__content p').contains('You have updated the capacity of A-1-001.')
       })
     })
+
+    context('when certificationApprovalRequired is ACTIVE and the working cap is temporarily increased', () => {
+      beforeEach(() => {
+        location.currentCellCertificate = {
+          ...location.currentCellCertificate,
+          certifiedNormalAccommodation: 2,
+          maxCapacity: 2,
+          workingCapacity: 1,
+        }
+        location.capacity = {
+          certifiedNormalAccommodation: 2,
+          maxCapacity: 2,
+          workingCapacity: 2,
+        }
+        location.status = 'ACTIVE'
+
+        cy.task('reset')
+        AuthStubber.stub.stubSignIn({ roles: ['MANAGE_RES_LOCATIONS_OP_CAP'] })
+        ManageUsersApiStubber.stub.stubManageUsers()
+        ManageUsersApiStubber.stub.stubManageUsersMe()
+        ManageUsersApiStubber.stub.stubManageUsersMeCaseloads()
+        ManageUsersApiStubber.stub.stubManageCaseloads()
+        LocationsApiStubber.stub.stubLocationsConstantsAccommodationType()
+        LocationsApiStubber.stub.stubLocationsConstantsConvertedCellType()
+        LocationsApiStubber.stub.stubLocationsConstantsDeactivatedReason()
+        LocationsApiStubber.stub.stubLocationsConstantsLocationType()
+        LocationsApiStubber.stub.stubLocationsConstantsApprovalType()
+        LocationsApiStubber.stub.stubLocationsConstantsSpecialistCellType()
+        LocationsApiStubber.stub.stubLocationsConstantsUsedForType()
+        LocationsApiStubber.stub.stubLocationsLocationsResidentialSummary()
+        LocationsApiStubber.stub.stubLocationsLocationsResidentialSummaryForLocation({ parentLocation: location })
+        LocationsApiStubber.stub.stubLocations(location)
+        LocationsApiStubber.stub.stubLocations(
+          LocationFactory.build({
+            id: '57718979-573c-433a-9e51-2d83f887c11c',
+            parentId: undefined,
+            topLevelId: undefined,
+          }),
+        )
+        LocationsApiStubber.stub.stubPrisonerLocationsId([])
+        LocationsApiStubber.stub.stubUpdateCapacity()
+        LocationsApiStubber.stub.stubGetPrisonConfiguration({ prisonId: 'TST', certificationActive: 'ACTIVE' })
+        cy.signIn()
+      })
+
+      it('skips to the confirmation page when there are no changes to the certified caps', () => {
+        ChangeCellCapacityPage.goTo('7e570000-0000-0000-0000-000000000001')
+        const changeCellCapacityPage = Page.verifyOnPage(ChangeCellCapacityPage)
+
+        changeCellCapacityPage.cnaInput().clear().type('2')
+        changeCellCapacityPage.maxCapacityInput().clear().type('2')
+        changeCellCapacityPage.workingCapacityInput().clear().type('1')
+        changeCellCapacityPage.continueButton().click()
+
+        cy.get('h1').contains('Confirm cell capacity')
+      })
+    })
   })
 })

--- a/server/controllers/changeCellCapacity/confirm.test.ts
+++ b/server/controllers/changeCellCapacity/confirm.test.ts
@@ -112,6 +112,18 @@ This will increase the establishment’s maximum capacity from 30 to 31.`,
         const result = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
         expect(result).not.toHaveProperty('showCertMismatchWarning')
       })
+
+      it('does not set showCertMismatchWarning when the new capacities match the cert', () => {
+        deepRes.locals.decoratedLocation.currentCellCertificate = {
+          certifiedNormalAccommodation: 2,
+          maxCapacity: 3,
+          workingCapacity: 1,
+        }
+        sessionModel.noChangeToCert = true
+
+        const result = controller.locals(deepReq as FormWizard.Request, deepRes as Response)
+        expect(result).not.toHaveProperty('showCertMismatchWarning')
+      })
     })
   })
 

--- a/server/controllers/changeCellCapacity/confirm.ts
+++ b/server/controllers/changeCellCapacity/confirm.ts
@@ -55,6 +55,7 @@ export default class ConfirmCellCapacity extends FormStep {
     const changeSummary = changeSummaries.join('\n<br/><br/>\n')
 
     const showCertMismatchWarning =
+      !req.sessionModel.get<boolean>('noChangeToCert') &&
       Boolean(req.sessionModel.get<boolean>('onlyWorkingCapChanged')) &&
       prisonConfiguration?.certificationApprovalRequired === 'ACTIVE' &&
       decoratedLocation.status !== 'DRAFT'

--- a/server/controllers/changeCellCapacity/index.test.ts
+++ b/server/controllers/changeCellCapacity/index.test.ts
@@ -224,6 +224,18 @@ describe('ChangeCellCapacity', () => {
 
       expect(deepReq.sessionModel.set).toHaveBeenCalledWith('onlyWorkingCapChanged', true)
     })
+
+    it('sets noChangeToCert flag when new values match the current cert', () => {
+      deepRes.locals.decoratedLocation.currentCellCertificate = {
+        certifiedNormalAccommodation: 2,
+        maxCapacity: 2,
+        workingCapacity: 1,
+      }
+      deepReq.form.values = { baselineCna: '2', maxCapacity: '2', workingCapacity: '1' }
+      controller.validate(deepReq as FormWizard.Request, deepRes as Response, jest.fn())
+
+      expect(deepReq.sessionModel.set).toHaveBeenCalledWith('noChangeToCert', true)
+    })
   })
 
   describe('locals', () => {

--- a/server/controllers/changeCellCapacity/index.ts
+++ b/server/controllers/changeCellCapacity/index.ts
@@ -78,6 +78,7 @@ export default class ChangeCellCapacity extends FormStep {
 
   override validate(req: FormWizard.Request, res: Response, next: NextFunction) {
     const { decoratedLocation, prisonConfiguration } = res.locals
+    const { currentCellCertificate } = decoratedLocation
     const { maxCapacity: newMaxCap, workingCapacity: newWorkingCap, baselineCna: newBaselineCna } = req.form.values
     const { maxCapacity, workingCapacity, baselineCna } = this.getInitialValues(req, res)
 
@@ -86,6 +87,11 @@ export default class ChangeCellCapacity extends FormStep {
     const maxCapChanged = Number(newMaxCap) !== maxCapacity
     const workingCapChanged = Number(newWorkingCap) !== workingCapacity
     const onlyWorkingCapChanged = !cnaChanged && !maxCapChanged && workingCapChanged
+    const noChangeToCert =
+      currentCellCertificate?.certifiedNormalAccommodation === Number(newBaselineCna) &&
+      currentCellCertificate?.maxCapacity === Number(newMaxCap) &&
+      currentCellCertificate?.workingCapacity === Number(newWorkingCap)
+    req.sessionModel.set('noChangeToCert', noChangeToCert)
 
     if (!cnaChanged && !maxCapChanged && !workingCapChanged) {
       return res.redirect(paths.location.view(decoratedLocation))

--- a/server/routes/changeCellCapacity/steps.ts
+++ b/server/routes/changeCellCapacity/steps.ts
@@ -21,6 +21,10 @@ const steps: FormWizard.Steps = {
     fields: ['baselineCna', 'workingCapacity', 'maxCapacity'],
     next: [
       {
+        fn: (req, res) => isCertActiveAndNotDraft(res.locals) && req.sessionModel.get('noChangeToCert'),
+        next: 'confirm',
+      },
+      {
         fn: (req, res) => isCertActiveAndNotDraft(res.locals) && !req.sessionModel.get('onlyWorkingCapChanged'),
         next: 'cert-change-disclaimer',
       },


### PR DESCRIPTION
Skip to confirm page when cell cap has been temporarily changed and we are trying to change it back to values that match the current cert.

[MAPA-320](https://dsdmoj.atlassian.net/browse/MAPA-320)

[MAPA-320]: https://dsdmoj.atlassian.net/browse/MAPA-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ