### PR TITLE
MAPA-163: Accessibility - Single-field page headings should label the field

### DIFF
--- a/server/controllers/changeLocalName/details.test.ts
+++ b/server/controllers/changeLocalName/details.test.ts
@@ -91,6 +91,7 @@ describe('Change Local Name', () => {
           localName: {
             component: 'govukCharacterCount',
             errorMessages: {
+              maxLength: 'Local name must be 30 characters or less',
               required: 'Enter a local name',
               taken: 'A location with this name already exists',
             },
@@ -105,8 +106,17 @@ describe('Change Local Name', () => {
             name: 'localName',
             classes: 'govuk-!-width-three-quarters local-name-text-input',
             label: {
-              text: 'Local name',
-              classes: 'govuk-fieldset__legend--m govuk-!-display-none',
+              text: 'Change local name',
+              classes: 'govuk-label--l govuk-!-margin-bottom-6',
+              for: 'localName',
+              isPageHeading: true,
+            },
+            formGroup: {
+              beforeInput: {
+                html: expect.stringContaining(
+                  'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
+                ),
+              },
             },
             maxlength: 30,
             rows: 1,
@@ -114,8 +124,6 @@ describe('Change Local Name', () => {
             value: 'Local name',
           },
         },
-        insetText:
-          'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
         validationErrors: [],
       })
     })

--- a/server/controllers/changeLocalName/details.ts
+++ b/server/controllers/changeLocalName/details.ts
@@ -23,8 +23,6 @@ export default class Details extends FormStep {
 
     return {
       ...locals,
-      insetText:
-        'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
       buttonText: 'Save name',
     }
   }

--- a/server/controllers/removeLocalName/check.test.ts
+++ b/server/controllers/removeLocalName/check.test.ts
@@ -3,7 +3,7 @@ import FormWizard from 'hmpo-form-wizard'
 import { DeepPartial } from 'fishery'
 import Check from './check'
 import LocationsService from '../../services/locationsService'
-import fields from '../../routes/changeLocalName/fields'
+import fields from '../../routes/removeLocalName/fields'
 import AnalyticsService from '../../services/analyticsService'
 import buildDecoratedLocation from '../../testutils/buildDecoratedLocation'
 import paths from '../../utils/paths'
@@ -87,33 +87,7 @@ describe('RemoveLocalName', () => {
 
       expect(controller.locals(deepReq as FormWizard.Request, deepRes as Response)).toEqual({
         buttonText: 'Remove name',
-        fields: {
-          localName: {
-            component: 'govukCharacterCount',
-            errorMessages: {
-              required: 'Enter a local name',
-              taken: 'A location with this name already exists',
-            },
-            validate: [
-              'required',
-              {
-                fn: expect.any(Function),
-                arguments: [30],
-              },
-            ],
-            id: 'localName',
-            name: 'localName',
-            classes: 'govuk-!-width-three-quarters local-name-text-input',
-            label: {
-              text: 'Local name',
-              classes: 'govuk-fieldset__legend--m govuk-!-display-none',
-            },
-            maxlength: 30,
-            rows: 1,
-            autocomplete: 'off',
-            value: null,
-          },
-        },
+        fields: {},
         validationErrors: [],
       })
     })

--- a/server/controllers/setLocalName/details.test.ts
+++ b/server/controllers/setLocalName/details.test.ts
@@ -90,6 +90,7 @@ describe('SetLocalName', () => {
           localName: {
             component: 'govukCharacterCount',
             errorMessages: {
+              maxLength: 'Local name must be 30 characters or less',
               required: 'Enter a local name',
               taken: 'A location with this name already exists',
             },
@@ -104,9 +105,17 @@ describe('SetLocalName', () => {
             name: 'localName',
             classes: 'govuk-!-width-three-quarters local-name-text-input',
             label: {
-              text: 'Local name',
+              text: 'Add local name',
+              classes: 'govuk-label--l govuk-!-margin-bottom-6',
               for: 'localName',
-              classes: 'govuk-!-display-none',
+              isPageHeading: true,
+            },
+            formGroup: {
+              beforeInput: {
+                html: expect.stringContaining(
+                  'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
+                ),
+              },
             },
             maxlength: 30,
             rows: 1,
@@ -114,8 +123,6 @@ describe('SetLocalName', () => {
             value: null,
           },
         },
-        insetText:
-          'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
         validationErrors: [],
       })
     })

--- a/server/controllers/setLocalName/details.ts
+++ b/server/controllers/setLocalName/details.ts
@@ -9,8 +9,6 @@ export default class Details extends FormStep {
   override locals(req: FormWizard.Request, res: Response): TypedLocals {
     return {
       ...super.locals(req, res),
-      insetText:
-        'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
       buttonText: 'Save name',
     }
   }

--- a/server/routes/archiveLocation/steps.ts
+++ b/server/routes/archiveLocation/steps.ts
@@ -33,6 +33,7 @@ const steps: FormWizard.Steps = {
     fields: ['reason'],
     controller: FormStep,
     next: 'update-signed-op-cap',
+    template: '../../partials/formStepNoTitle',
   },
   ...UpdateSignedOpCap.getSteps({ next: 'submit-certification-approval-request' }),
   ...SubmitCertificationApprovalRequest.getSteps({ next: '#' }),

--- a/server/routes/changeLocalName/fields.ts
+++ b/server/routes/changeLocalName/fields.ts
@@ -1,3 +1,4 @@
+import renderMacro from '../../utils/renderMacro'
 import maxLength from '../../validators/maxLength'
 
 const fields = {
@@ -5,16 +6,30 @@ const fields = {
     component: 'govukCharacterCount',
     validate: ['required', maxLength(30)],
     maxlength: 30,
-    errorMessages: { required: 'Enter a local name', taken: 'A location with this name already exists' },
+    errorMessages: {
+      maxLength: 'Local name must be 30 characters or less',
+      required: 'Enter a local name',
+      taken: 'A location with this name already exists',
+    },
     id: 'localName',
     name: 'localName',
     classes: 'govuk-!-width-three-quarters local-name-text-input',
     rows: 1,
     label: {
-      text: 'Local name',
-      classes: 'govuk-fieldset__legend--m govuk-!-display-none',
+      text: 'Change local name',
+      classes: 'govuk-label--l govuk-!-margin-bottom-6',
+      for: 'localName',
+      isPageHeading: true,
     },
     autocomplete: 'off',
+    formGroup: {
+      beforeInput: {
+        html: renderMacro('govuk/components/inset-text/macro', 'govukInsetText', {
+          text: 'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
+          classes: 'govuk-!-margin-bottom-6',
+        }),
+      },
+    },
   },
 }
 

--- a/server/routes/changeLocalName/steps.ts
+++ b/server/routes/changeLocalName/steps.ts
@@ -14,7 +14,7 @@ const steps: FormWizard.Steps = {
   '/details': {
     fields: ['localName'],
     controller: Details,
-    template: '../../partials/formStep',
+    template: '../../partials/formStepNoTitle',
     pageTitle: 'Change local name',
   },
 }

--- a/server/routes/setLocalName/fields.ts
+++ b/server/routes/setLocalName/fields.ts
@@ -1,3 +1,4 @@
+import renderMacro from '../../utils/renderMacro'
 import maxLength from '../../validators/maxLength'
 
 const fields = {
@@ -5,17 +6,30 @@ const fields = {
     component: 'govukCharacterCount',
     validate: ['required', maxLength(30)],
     maxlength: 30,
-    errorMessages: { required: 'Enter a local name', taken: 'A location with this name already exists' },
+    errorMessages: {
+      maxLength: 'Local name must be 30 characters or less',
+      required: 'Enter a local name',
+      taken: 'A location with this name already exists',
+    },
     id: 'localName',
     name: 'localName',
     classes: 'govuk-!-width-three-quarters local-name-text-input',
     rows: 1,
     label: {
-      text: 'Local name',
-      classes: 'govuk-!-display-none',
+      text: 'Add local name',
+      classes: 'govuk-label--l govuk-!-margin-bottom-6',
       for: 'localName',
+      isPageHeading: true,
     },
     autocomplete: 'off',
+    formGroup: {
+      beforeInput: {
+        html: renderMacro('govuk/components/inset-text/macro', 'govukInsetText', {
+          text: 'This will change how the name displays on location lists but won’t change the location code (for example A-1-001).',
+          classes: 'govuk-!-margin-bottom-6',
+        }),
+      },
+    },
   },
 }
 

--- a/server/routes/setLocalName/steps.ts
+++ b/server/routes/setLocalName/steps.ts
@@ -15,7 +15,7 @@ const steps: FormWizard.Steps = {
     fields: ['localName'],
     controller: Details,
     pageTitle: 'Add local name',
-    template: '../../partials/formStep',
+    template: '../../partials/formStepNoTitle',
   },
 }
 

--- a/server/utils/renderMacro.ts
+++ b/server/utils/renderMacro.ts
@@ -1,4 +1,17 @@
 import nunjucks from 'nunjucks'
+import path from 'path'
+
+// Own Environment with explicit search paths so this doesn't depend on nunjucks.configure()
+// having already run elsewhere (some callers render macros at module load time).
+const env = new nunjucks.Environment(
+  new nunjucks.FileSystemLoader([
+    path.join(__dirname, '../views'),
+    'node_modules/govuk-frontend/dist/',
+    'node_modules/@ministryofjustice/frontend/',
+    'node_modules/@ministryofjustice/frontend/moj/components/',
+  ]),
+  { autoescape: true },
+)
 
 export default function renderMacro(macroPath: string, macroName: string, params: object) {
   const macroParams = JSON.stringify(params, null, 2)
@@ -7,5 +20,5 @@ export default function renderMacro(macroPath: string, macroName: string, params
       {{- ${macroName}(${macroParams}) -}}
     `
 
-  return nunjucks.renderString(macroString, undefined)
+  return env.renderString(macroString, undefined)
 }

--- a/server/views/partials/formStepNoTitle.njk
+++ b/server/views/partials/formStepNoTitle.njk
@@ -1,4 +1,4 @@
-{% extends "../../partials/formStep.njk" %}
+{% extends "./formStep.njk" %}
 
 {% block outerHeading %}
   <div class="govuk-grid-row govuk-!-margin-bottom-0">


### PR DESCRIPTION
Use the field label as the page header on the local name pages so that screen readers are properly aware of their meaning.

[MAPA-163](https://dsdmoj.atlassian.net/browse/MAPA-163)

[MAPA-163]: https://dsdmoj.atlassian.net/browse/MAPA-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ