### PR TITLE
MAPA-336 Send the uploaded capacities as stated and validate them before upload

### DIFF
--- a/server/controllers/cellCertificateUploads/detail.test.ts
+++ b/server/controllers/cellCertificateUploads/detail.test.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { DeepPartial } from 'fishery'
-import ingestDetail, { capacityCell, changeText } from './detail'
+import ingestDetail, { capacityCell, changeText, heldAndCertifiedCell, maxCapacityCell } from './detail'
 import LocationsService from '../../services/locationsService'
 import { CellCertificateUpload } from '../../data/types/locationsApi/cellCertificateUpload'
 
@@ -75,6 +75,43 @@ describe('Cell certificate uploads - detail', () => {
     })
   })
 
+  describe('heldAndCertifiedCell', () => {
+    it('shows the held value alone when the certificate agrees', () => {
+      expect(heldAndCertifiedCell(2, 2)).toEqual({ text: '2' })
+      expect(heldAndCertifiedCell(0, 0)).toEqual({ text: '0' })
+    })
+
+    it('shows the certified value beneath the held one when they differ', () => {
+      expect(heldAndCertifiedCell(1, 2)).toEqual({ text: '1', certifiedText: '2' })
+      expect(heldAndCertifiedCell(2, 0)).toEqual({ text: '2', certifiedText: '0' })
+      expect(heldAndCertifiedCell(undefined, 0)).toEqual({ text: '-', certifiedText: '0' })
+    })
+  })
+
+  describe('maxCapacityCell', () => {
+    it('shows the change the location took, with the certified value when it differs', () => {
+      // a certified max capacity of 0 the location had to take as 1
+      expect(maxCapacityCell({ previousMaxCapacity: 2, maxCapacity: 0, appliedMaxCapacity: 1 })).toEqual({
+        text: '2 → 1',
+        certifiedText: '0',
+      })
+    })
+
+    it('shows no change when the location took the certified value', () => {
+      expect(maxCapacityCell({ previousMaxCapacity: 2, maxCapacity: 3, appliedMaxCapacity: 3 })).toEqual({
+        text: '2 → 3',
+      })
+    })
+
+    it('falls back to the mismatch flag for uploads processed before the applied value was recorded', () => {
+      expect(maxCapacityCell({ previousMaxCapacity: 2, maxCapacity: 3 })).toEqual({ text: '2 → 3' })
+      expect(maxCapacityCell({ previousMaxCapacity: 2, maxCapacity: 1, maxCapacityMismatch: true })).toEqual({
+        text: '2',
+        certifiedText: '1',
+      })
+    })
+  })
+
   describe('changeText', () => {
     it('shows new value only when unchanged or no previous (handles 0)', () => {
       expect(changeText(undefined, 2)).toBe('2')
@@ -111,6 +148,41 @@ describe('Cell certificate uploads - detail', () => {
             status: 'SKIPPED',
             needsReview: false,
             message: 'No changes required',
+          }),
+        ],
+      }),
+    )
+  })
+
+  it('never shows a working capacity as a change, because an ingestion cannot make one', async () => {
+    // a temporarily deactivated cell: the mismatch flag is deliberately suppressed for these, but the
+    // location still did not move its working capacity to the uploaded value
+    locationsService.getCellCertificateUpload = jest.fn().mockResolvedValue({
+      ...upload,
+      locations: [
+        {
+          locationKey: 'TST-G-2-010',
+          status: 'PROCESSED',
+          maxCapacity: 0,
+          workingCapacity: 2,
+          previousMaxCapacity: 2,
+          appliedMaxCapacity: 1,
+          previousWorkingCapacity: 1,
+        },
+      ],
+    } as CellCertificateUpload)
+
+    await ingestDetail(deepReq as Request, deepRes as Response)
+
+    expect(deepRes.render).toHaveBeenCalledWith(
+      'pages/cellCertificateUploads/detail',
+      expect.objectContaining({
+        locationRows: [
+          expect.objectContaining({
+            locationKey: 'TST-G-2-010',
+            needsReview: false,
+            workingCapacity: { text: '1', certifiedText: '2' },
+            maxCapacity: { text: '2 → 1', certifiedText: '0' },
           }),
         ],
       }),

--- a/server/controllers/cellCertificateUploads/detail.ts
+++ b/server/controllers/cellCertificateUploads/detail.ts
@@ -23,6 +23,32 @@ export const capacityCell = (
   }
 }
 
+// Shows what the location holds, with the certified value beneath it when the two differ. Used where the
+// uploaded value is never applied to the location, so the column can never show a change.
+export const heldAndCertifiedCell = (held: number | undefined, certified: number | undefined): CapacityCell => {
+  const text = held === undefined || held === null ? '-' : String(held)
+  if (certified === undefined || certified === null || certified === held) return { text }
+  return { text, certifiedText: String(certified) }
+}
+
+// The location's max capacity can differ from the certified one even when the upload was applied, because a
+// location cannot hold a max capacity of zero and the API raises it to one. Uploads processed before that
+// value was recorded fall back to inferring it from the mismatch flag.
+export const maxCapacityCell = (location: {
+  previousMaxCapacity?: number
+  maxCapacity?: number
+  appliedMaxCapacity?: number
+  maxCapacityMismatch?: boolean
+}): CapacityCell => {
+  const applied =
+    location.appliedMaxCapacity ?? (location.maxCapacityMismatch ? location.previousMaxCapacity : location.maxCapacity)
+
+  return {
+    ...heldAndCertifiedCell(applied, location.maxCapacity),
+    text: changeText(location.previousMaxCapacity, applied),
+  }
+}
+
 export default async (req: Request, res: Response) => {
   const { locationsService } = req.services
   const { systemToken } = req.session
@@ -42,12 +68,10 @@ export default async (req: Request, res: Response) => {
         location.maxCapacityMismatch ||
         location.certifiedNormalAccommodationMismatch,
       ),
-      maxCapacity: capacityCell(location.previousMaxCapacity, location.maxCapacity, location.maxCapacityMismatch),
-      workingCapacity: capacityCell(
-        location.previousWorkingCapacity,
-        location.workingCapacity,
-        location.workingCapacityMismatch,
-      ),
+      maxCapacity: maxCapacityCell(location),
+      // an ingestion never moves a location's working capacity, so this column shows what the location holds
+      // and what the certificate records - never a change
+      workingCapacity: heldAndCertifiedCell(location.previousWorkingCapacity, location.workingCapacity),
       certifiedNormalAccommodation: capacityCell(
         location.previousCertifiedNormalAccommodation,
         location.certifiedNormalAccommodation,

--- a/server/controllers/cellCertificateUploads/upload.test.ts
+++ b/server/controllers/cellCertificateUploads/upload.test.ts
@@ -83,7 +83,7 @@ describe('Upload file csv', () => {
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          file: controller.formError('file', 'ingest', 'The CNA value is not numeric for cell LGI-S-0-032'),
+          file: controller.formError('file', 'ingest', 'The CNA value is not numeric for cell LGI-S-0-032.'),
         }),
       )
     })
@@ -98,7 +98,7 @@ describe('Upload file csv', () => {
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          file: controller.formError('file', 'ingest', 'The Max Cap value is not numeric for cell LGI-S-0-032'),
+          file: controller.formError('file', 'ingest', 'The Max Cap value is not numeric for cell LGI-S-0-032.'),
         }),
       )
     })
@@ -116,7 +116,9 @@ describe('Upload file csv', () => {
           file: controller.formError(
             'file',
             'ingest',
-            'The Working Cap value (2) is more than the Max Cap value (0) for cell LPI-G-2-002',
+            'The Working Cap value is more than the Max Cap value for cell LPI-G-2-002. A cell cannot be ' +
+              'certified to hold more people than its maximum capacity, so check the "Maximum number of ' +
+              'prisoners" and "Number of places allocated" columns.',
           ),
         }),
       )
@@ -132,7 +134,7 @@ describe('Upload file csv', () => {
 
       expect(callback).toHaveBeenCalledWith(
         expect.objectContaining({
-          file: controller.formError('file', 'ingest', 'The Working Cap value is not numeric for cell TST-HB1-1-005'),
+          file: controller.formError('file', 'ingest', 'The Working Cap value is not numeric for cell TST-HB1-1-005.'),
         }),
       )
     })
@@ -150,7 +152,7 @@ describe('Upload file csv', () => {
           file: controller.formError(
             'file',
             'ingest',
-            'Row 2: the Number or cell mark value "01-Jan" looks like a date for cell DNI-H1-A1-001',
+            'Row 2: the Number or cell mark value "01-Jan" looks like a date for cell DNI-H1-A1-001.',
           ),
         }),
       )
@@ -273,8 +275,8 @@ describe('Upload file csv', () => {
       ]
 
       expect(() => parseCsvRow(input)).toThrow(
-        'Row 2: the Number or cell mark value "01-Jan" looks like a date for cell DNI-HB1-1-001\n' +
-          'Row 3: the Number or cell mark value "01-Feb" looks like a date for cell DNI-HB1-1-002',
+        'Row 2: the Number or cell mark value "01-Jan" looks like a date for cell DNI-HB1-1-001. ' +
+          'Row 3: the Number or cell mark value "01-Feb" looks like a date for cell DNI-HB1-1-002.',
       )
     })
 
@@ -294,7 +296,7 @@ describe('Upload file csv', () => {
       const input = ['HB1,EYI-HB1-1-002,A1-02,2,0,2,Closed for refurb,FALSE']
 
       expect(() => parseCsvRow(input)).toThrow(
-        'The Working Cap value (2) is more than the Max Cap value (0) for cell EYI-HB1-1-002',
+        'The Working Cap value is more than the Max Cap value for cell EYI-HB1-1-002.',
       )
     })
 
@@ -311,13 +313,28 @@ describe('Upload file csv', () => {
       expect(() => parseCsvRow(input)).not.toThrow('is more than the Max Cap value')
     })
 
-    it('lists only the first ten errors, then a count of the rest', () => {
+    it('reports rows that failed the same way once, naming a few cells and counting the rest', () => {
       const input = Array.from(
-        { length: 12 },
-        (_, index) => `HB1,EYI-HB1-1-${String(index).padStart(3, '0')},A1-01,2,0,2,Closed for refurb,FALSE`,
+        { length: 8 },
+        (_, index) => `HB1,EYI-HB1-1-00${index},A1-01,2,0,2,Closed for refurb,FALSE`,
       )
 
-      expect(() => parseCsvRow(input)).toThrow(/and 2 more row\(s\) have errors\.$/)
+      expect(() => parseCsvRow(input)).toThrow(
+        'The Working Cap value is more than the Max Cap value for cells EYI-HB1-1-000, EYI-HB1-1-001, ' +
+          'EYI-HB1-1-002, EYI-HB1-1-003, EYI-HB1-1-004 and 3 others.',
+      )
+    })
+
+    it('reports each kind of problem separately', () => {
+      const input = [
+        'HB1,EYI-HB1-1-001,A1-01,2,0,2,Closed for refurb,FALSE',
+        'HB1,EYI-HB1-1-002,A1-02,x,2,2,Normal Accommodation,TRUE',
+      ]
+
+      expect(() => parseCsvRow(input)).toThrow('The CNA value is not numeric for cell EYI-HB1-1-002.')
+      expect(() => parseCsvRow(input)).toThrow(
+        'The Working Cap value is more than the Max Cap value for cell EYI-HB1-1-001.',
+      )
     })
 
     it('handles null inCellSanitation', () => {

--- a/server/controllers/cellCertificateUploads/upload.test.ts
+++ b/server/controllers/cellCertificateUploads/upload.test.ts
@@ -103,6 +103,40 @@ describe('Upload file csv', () => {
       )
     })
 
+    it('validation failure for a working capacity above the max capacity', async () => {
+      deepReq.file = {
+        path: 'uploads/testdata/working-cap-exceeds-max.csv',
+      } as unknown as Express.Multer.File
+
+      const callback = jest.fn()
+      await controller.validateFields(deepReq as FormWizard.Request, deepRes as Response, callback)
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file: controller.formError(
+            'file',
+            'ingest',
+            'The Working Cap value (2) is more than the Max Cap value (0) for cell LPI-G-2-002',
+          ),
+        }),
+      )
+    })
+
+    it('validation failure for an incorrectly formatted working cap value in the file', async () => {
+      deepReq.file = {
+        path: 'uploads/testdata/bad-format.csv',
+      } as unknown as Express.Multer.File
+
+      const callback = jest.fn()
+      await controller.validateFields(deepReq as FormWizard.Request, deepRes as Response, callback)
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          file: controller.formError('file', 'ingest', 'The Working Cap value is not numeric for cell TST-HB1-1-005'),
+        }),
+      )
+    })
+
     it('validation failure for a cell mark that looks like a date', async () => {
       deepReq.file = {
         path: 'uploads/testdata/date-like-cell-mark.csv',
@@ -244,16 +278,46 @@ describe('Upload file csv', () => {
       )
     })
 
-    it('defaults maxCapacity to 1 if 0 is provided', () => {
-      const input = ['HB1,EYI-HB1-1-002,A1-02,1,0,1,Normal Accommodation,FALSE']
+    it('keeps a max capacity of 0 as uploaded', () => {
+      const input = ['HB1,EYI-HB1-1-002,A1-02,1,0,0,Normal Accommodation,FALSE']
       const result = parseCsvRow(input)
-      expect(result['EYI-HB1-1-002'].maxCapacity).toBe(1)
+      expect(result['EYI-HB1-1-002'].maxCapacity).toBe(0)
     })
 
-    it('defaults workingCapacity to 0 if null is provided', () => {
+    it('rejects a working capacity that is not numeric', () => {
       const input = ['HB1,EYI-HB1-1-003,A1-03,3,3,null,Normal Accommodation,TRUE']
-      const result = parseCsvRow(input)
-      expect(result['EYI-HB1-1-003'].workingCapacity).toBe(0)
+
+      expect(() => parseCsvRow(input)).toThrow('The Working Cap value is not numeric for cell EYI-HB1-1-003')
+    })
+
+    it('rejects a working capacity above the max capacity', () => {
+      const input = ['HB1,EYI-HB1-1-002,A1-02,2,0,2,Closed for refurb,FALSE']
+
+      expect(() => parseCsvRow(input)).toThrow(
+        'The Working Cap value (2) is more than the Max Cap value (0) for cell EYI-HB1-1-002',
+      )
+    })
+
+    it('allows a working capacity equal to the max capacity', () => {
+      const input = ['HB1,EYI-HB1-1-002,A1-02,2,2,2,Normal Accommodation,FALSE']
+
+      expect(() => parseCsvRow(input)).not.toThrow()
+    })
+
+    it('does not compare the capacities when either is not numeric', () => {
+      const input = ['HB1,EYI-HB1-1-002,A1-02,2,x,2,Normal Accommodation,FALSE']
+
+      expect(() => parseCsvRow(input)).toThrow('The Max Cap value is not numeric for cell EYI-HB1-1-002')
+      expect(() => parseCsvRow(input)).not.toThrow('is more than the Max Cap value')
+    })
+
+    it('lists only the first ten errors, then a count of the rest', () => {
+      const input = Array.from(
+        { length: 12 },
+        (_, index) => `HB1,EYI-HB1-1-${String(index).padStart(3, '0')},A1-01,2,0,2,Closed for refurb,FALSE`,
+      )
+
+      expect(() => parseCsvRow(input)).toThrow(/and 2 more row\(s\) have errors\.$/)
     })
 
     it('handles null inCellSanitation', () => {
@@ -271,8 +335,8 @@ describe('Upload file csv', () => {
     it('parses multiple rows correctly', () => {
       const input = [
         'HB1,EYI-HB1-1-001,A1-01,2,2,1,Normal Accommodation,TRUE',
-        'HB1,EYI-HB1-1-002,A1-02,1,0,1,Normal Accommodation,FALSE',
-        'HB1,EYI-HB1-1-003,A1-03,3,3,null,Normal Accommodation,TRUE',
+        'HB1,EYI-HB1-1-002,A1-02,1,0,0,Normal Accommodation,FALSE',
+        'HB1,EYI-HB1-1-003,A1-03,3,3,0,Normal Accommodation,TRUE',
         'HB2,EYI-HB2-1-004,A1-04,1,1,1,Normal Accommodation,null',
         'HB2,EYI-HB2-1-005,A1-05,5,2,2,Normal Accommodation,TRUE',
       ]
@@ -288,15 +352,15 @@ describe('Upload file csv', () => {
           inCellSanitation: true,
         },
         'EYI-HB1-1-002': {
-          maxCapacity: 1, // 0 becomes 1
-          workingCapacity: 1,
+          maxCapacity: 0, // sent as uploaded
+          workingCapacity: 0,
           certifiedNormalAccommodation: 1,
           cellMark: 'A1-02',
           inCellSanitation: false,
         },
         'EYI-HB1-1-003': {
           maxCapacity: 3,
-          workingCapacity: 0, // null becomes 0
+          workingCapacity: 0,
           certifiedNormalAccommodation: 3,
           cellMark: 'A1-03',
           inCellSanitation: true,

--- a/server/controllers/cellCertificateUploads/upload.ts
+++ b/server/controllers/cellCertificateUploads/upload.ts
@@ -75,6 +75,8 @@ export function readCsvFile(path: string): string[] {
     .slice(1) // Skip header
 }
 
+const MAX_VALIDATION_ERRORS_SHOWN = 10
+
 export function parseCsvRow(rows: string[]): BulkCapacityUpdate {
   const validationErrors: string[] = []
   const capacityData = rows.reduce<BulkCapacityUpdate>((acc, row, index) => {
@@ -98,20 +100,30 @@ export function parseCsvRow(rows: string[]): BulkCapacityUpdate {
       : undefined
 
     const maxCapacityError = getNumericValidationError(maxCapacity, 'Max Cap', cellNumberValue)
+    const workingCapacityError = getNumericValidationError(workingCapacity, 'Working Cap', cellNumberValue)
     const cnaError = getNumericValidationError(certifiedNormalAccommodation, 'CNA', cellNumberValue)
     const cellMarkError = getCellMarkValidationError(cellMark, cellNumberValue, rowNumber)
+    // only worth comparing once both values are known to be numbers
+    const capacityError =
+      maxCapacityError || workingCapacityError
+        ? undefined
+        : getCapacityValidationError(workingCapacity, maxCapacity, cellNumberValue)
 
     if (maxCapacityError) validationErrors.push(maxCapacityError)
+    if (workingCapacityError) validationErrors.push(workingCapacityError)
     if (cnaError) validationErrors.push(cnaError)
     if (cellMarkError) validationErrors.push(cellMarkError)
+    if (capacityError) validationErrors.push(capacityError)
 
-    if (maxCapacityError || cnaError || cellMarkError) {
+    if (maxCapacityError || workingCapacityError || cnaError || cellMarkError || capacityError) {
       return acc
     }
 
     acc[cellNumberValue] = {
-      maxCapacity: parseInt(maxCapacity, 10) === 0 ? 1 : parseInt(maxCapacity, 10),
-      workingCapacity: parseInt(workingCapacity, 10) ? parseInt(workingCapacity, 10) : 0,
+      // sent as uploaded: the certificate must record what the prison stated. A location cannot hold a max
+      // capacity of zero, so the API raises the value it writes onto the location itself.
+      maxCapacity: parseInt(maxCapacity, 10),
+      workingCapacity: parseInt(workingCapacity, 10),
       certifiedNormalAccommodation: parseInt(certifiedNormalAccommodation, 10),
       cellMark,
       inCellSanitation: sanitation,
@@ -121,10 +133,25 @@ export function parseCsvRow(rows: string[]): BulkCapacityUpdate {
   }, {})
 
   if (validationErrors.length) {
-    throw new Error(validationErrors.join('\n'))
+    // a spreadsheet can be wrong in hundreds of rows at once, and an error summary listing every one of
+    // them is no more useful than the first few
+    const shown = validationErrors.slice(0, MAX_VALIDATION_ERRORS_SHOWN)
+    const remaining = validationErrors.length - shown.length
+    if (remaining > 0) shown.push(`and ${remaining} more row(s) have errors.`)
+    throw new Error(shown.join('\n'))
   }
 
   return capacityData
+}
+
+// A cell cannot be certified to hold more prisoners than its max capacity allows, and the API rejects the
+// whole upload for it - so catch it here, where the message can name the cell.
+function getCapacityValidationError(workingCapacity: string, maxCapacity: string, cellNumber: string) {
+  if (Number(workingCapacity) > Number(maxCapacity)) {
+    return `The Working Cap value (${Number(workingCapacity)}) is more than the Max Cap value (${Number(maxCapacity)}) for cell ${cellNumber}`
+  }
+
+  return undefined
 }
 
 function getNumericValidationError(value: string | undefined, type: string, cellNumber: string) {

--- a/server/controllers/cellCertificateUploads/upload.ts
+++ b/server/controllers/cellCertificateUploads/upload.ts
@@ -75,10 +75,17 @@ export function readCsvFile(path: string): string[] {
     .slice(1) // Skip header
 }
 
-const MAX_VALIDATION_ERRORS_SHOWN = 10
+/** How many cells to name before falling back to a count of the rest. */
+const MAX_CELLS_LISTED = 5
+
+/**
+ * One problem found on one row. The cell is held separately from the wording so that rows failing in the
+ * same way can be reported together - a spreadsheet is typically wrong in the same way many times over.
+ */
+type RowValidationError = { before: string; cell: string; after?: string }
 
 export function parseCsvRow(rows: string[]): BulkCapacityUpdate {
-  const validationErrors: string[] = []
+  const validationErrors: RowValidationError[] = []
   const capacityData = rows.reduce<BulkCapacityUpdate>((acc, row, index) => {
     const [
       ,
@@ -133,36 +140,80 @@ export function parseCsvRow(rows: string[]): BulkCapacityUpdate {
   }, {})
 
   if (validationErrors.length) {
-    // a spreadsheet can be wrong in hundreds of rows at once, and an error summary listing every one of
-    // them is no more useful than the first few
-    const shown = validationErrors.slice(0, MAX_VALIDATION_ERRORS_SHOWN)
-    const remaining = validationErrors.length - shown.length
-    if (remaining > 0) shown.push(`and ${remaining} more row(s) have errors.`)
-    throw new Error(shown.join('\n'))
+    throw new Error(summariseValidationErrors(validationErrors))
   }
 
   return capacityData
 }
 
+/**
+ * Turns the per-row problems into a message a user can act on. The error summary renders as plain text, so
+ * newlines would collapse into one run-on line - and 88 near-identical lines would not help anyone anyway.
+ * Rows that failed in the same way are reported once, naming the first few cells and counting the rest.
+ */
+function summariseValidationErrors(errors: RowValidationError[]): string {
+  const groups = new Map<string, { error: RowValidationError; cells: string[] }>()
+
+  errors.forEach(error => {
+    const key = `${error.before}|${error.after ?? ''}`
+    const group = groups.get(key) ?? { error, cells: [] }
+    group.cells.push(error.cell)
+    groups.set(key, group)
+  })
+
+  return [...groups.values()]
+    .map(({ error, cells }) => [`${error.before} ${listCells(cells)}.`, error.after].filter(Boolean).join(' '))
+    .join(' ')
+}
+
+function listCells(cells: string[]): string {
+  const shown = cells.slice(0, MAX_CELLS_LISTED)
+  const remaining = cells.length - shown.length
+
+  if (remaining === 0) {
+    return shown.length === 1 ? `cell ${shown[0]}` : `cells ${shown.join(', ')}`
+  }
+
+  return `cells ${shown.join(', ')} and ${remaining} ${remaining === 1 ? 'other' : 'others'}`
+}
+
 // A cell cannot be certified to hold more prisoners than its max capacity allows, and the API rejects the
-// whole upload for it - so catch it here, where the message can name the cell.
-function getCapacityValidationError(workingCapacity: string, maxCapacity: string, cellNumber: string) {
+// whole upload for it - so catch it here, where the message can name the cells and the columns to check.
+function getCapacityValidationError(
+  workingCapacity: string,
+  maxCapacity: string,
+  cellNumber: string,
+): RowValidationError | undefined {
   if (Number(workingCapacity) > Number(maxCapacity)) {
-    return `The Working Cap value (${Number(workingCapacity)}) is more than the Max Cap value (${Number(maxCapacity)}) for cell ${cellNumber}`
+    return {
+      before: 'The Working Cap value is more than the Max Cap value for',
+      cell: cellNumber,
+      after:
+        'A cell cannot be certified to hold more people than its maximum capacity, so check the ' +
+        '"Maximum number of prisoners" and "Number of places allocated" columns.',
+    }
   }
 
   return undefined
 }
 
-function getNumericValidationError(value: string | undefined, type: string, cellNumber: string) {
+function getNumericValidationError(
+  value: string | undefined,
+  type: string,
+  cellNumber: string,
+): RowValidationError | undefined {
   if (value === undefined || value.trim() === '' || Number.isNaN(Number(value))) {
-    return `The ${type} value is not numeric for cell ${cellNumber}`
+    return { before: `The ${type} value is not numeric for`, cell: cellNumber }
   }
 
   return undefined
 }
 
-function getCellMarkValidationError(value: string | undefined, cellNumber: string, rowNumber: number) {
+function getCellMarkValidationError(
+  value: string | undefined,
+  cellNumber: string,
+  rowNumber: number,
+): RowValidationError | undefined {
   const cellMark = value?.trim()
 
   if (!cellMark) {
@@ -170,7 +221,10 @@ function getCellMarkValidationError(value: string | undefined, cellNumber: strin
   }
 
   if (looksLikeDate(cellMark)) {
-    return `Row ${rowNumber}: the Number or cell mark value "${cellMark}" looks like a date for cell ${cellNumber}`
+    return {
+      before: `Row ${rowNumber}: the Number or cell mark value "${cellMark}" looks like a date for`,
+      cell: cellNumber,
+    }
   }
 
   return undefined

--- a/server/data/types/locationsApi/cellCertificateUpload.d.ts
+++ b/server/data/types/locationsApi/cellCertificateUpload.d.ts
@@ -13,6 +13,7 @@ export declare interface CellCertificateUploadLocation {
   cellMark?: string
   inCellSanitation?: boolean
   previousMaxCapacity?: number
+  appliedMaxCapacity?: number
   previousWorkingCapacity?: number
   previousCertifiedNormalAccommodation?: number
   previousCellMark?: string

--- a/uploads/testdata/working-cap-exceeds-max.csv
+++ b/uploads/testdata/working-cap-exceeds-max.csv
@@ -1,0 +1,2 @@
+Wing / Unit,P-Nomis Cell Number,Number or cell mark,Certified Normal Accommodation (Baseline CNA),Maximum number of prisoners,Number of places allocated,Used for,Cell Sanitation
+G Wing,LPI-G-2-002,G2-2,2,0,2,Closed for refurb,


### PR DESCRIPTION
## Problem

A cell certificate import at HMP Liverpool produced certificate rows with a **certified working capacity above the certified max capacity** — G wing cells showing CNA 2 / CWC 2 / max 1.

`parseCsvRow` rewrote a `Max Cap` of 0 to 1 before sending it, because a location cannot hold a max capacity of zero. That rewritten value was also what ended up on the cell certificate, so a row uploaded as `CNA 2 / max 0 / 2 places allocated` was certified as max 1 with a working capacity of 2.

## Changes

**Send what the prison stated.** The `0 → 1` rewrite is gone; the API now applies that floor itself, only to the value it writes onto the location (ministryofjustice/hmpps-locations-inside-prison-api#743).

**Validate the working capacity.** It was not validated at all — a non-numeric value silently became 0 — and nothing checked it against the max capacity. Both are now checked in `parseCsvRow` alongside the existing Max Cap / CNA / cell-mark rules, so an invalid file is refused with a message naming the cell. A spreadsheet can be wrong in hundreds of rows at once, so the summary lists the first ten and counts the rest.

**Correct two columns on the import report.**

- *Working capacity* showed `1 → 2` for temporarily deactivated cells (LPI-G-2-010) and `2 → 0` for others (LPI-A-2-014), implying the location's working capacity had moved. An ingestion never moves a location's working capacity at all — the mismatch flag is deliberately suppressed for temporarily deactivated cells and the UI was reading "no mismatch" as "the change was applied". That column now shows what the location holds with the certified value beneath it, and can never render an arrow. Fixing it here rather than in the API also corrects the rendering of the existing pre-prod report and every historical one, since the flags are already persisted.
- *Max capacity* now uses `appliedMaxCapacity` from the API, so a row certified at 0 that the location had to take as 1 reads `2 → 1` with "Certified 0" rather than claiming the location went to 0. Uploads processed before that field existed fall back to the old inference, so historical reports render as they did.

## Knock-on

Confirm-page wing totals will now reflect the true uploaded max capacities, so they drop for prisons with `Max 0` rows. That is the correction, not a regression — but MAPA-320 compares those figures with the current certificate to decide whether to skip to the confirm page.

## Sequencing

Merge and deploy **after** the API change, which must tolerate `maxCapacity: 0` before this starts sending it.

## Testing

- Full suite green (1217 tests), lint and typecheck clean.
- New `parseCsvRow` cases: max 0 kept as uploaded; non-numeric working capacity rejected; working above max rejected; working equal to max allowed; no capacity comparison when either value is not a number; errors capped at ten plus a count.
- New `validateFields` cases for a working capacity above the max, and for the non-numeric working capacity in `bad-format.csv` (which no test had been using).
- New report cases for `heldAndCertifiedCell` / `maxCapacityCell`, plus a regression test that a temporarily deactivated cell renders `1` + "Certified 2" and never `1 → 2`.
- Verified against the real Liverpool file: it is now refused, naming exactly the 88 bad G-wing rows. With those corrected it is accepted, and the "toilet"-style rows (`0,0,0`) come through as max 0 rather than the old coerced 1.

https://dsdmoj.atlassian.net/browse/MAPA-336